### PR TITLE
Topic based schedule updates

### DIFF
--- a/Mirror.plist
+++ b/Mirror.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>clang_version</key>
+<string>clang version 10.0.0-4ubuntu1 </string>
+ <key>diagnostics</key>
+ <array>
+ </array>
+ <key>files</key>
+ <array>
+ </array>
+</dict>
+</plist>

--- a/rmf_traffic/include/rmf_traffic/Region.hpp
+++ b/rmf_traffic/include/rmf_traffic/Region.hpp
@@ -165,7 +165,32 @@ extern template class bidirectional_iterator<
     const geometry::Space, Region::IterImpl, Region
 >;
 
+// Equality
 } // namespace detail
+
+//==============================================================================
+/// Equality operator for Region objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator==(
+  const Region& lhs,
+  const Region& rhs);
+
+//==============================================================================
+/// Non-equality operator for Region objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator!=(
+  const Region& lhs,
+  const Region& rhs);
 
 } // namespace rmf_traffic
 

--- a/rmf_traffic/include/rmf_traffic/geometry/Circle.hpp
+++ b/rmf_traffic/include/rmf_traffic/geometry/Circle.hpp
@@ -49,6 +49,30 @@ public:
 
 };
 
+//==============================================================================
+/// Equality operator for Circle objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator==(
+  const Circle& lhs,
+  const Circle& rhs);
+
+//==============================================================================
+/// Non-equality operator for Circle objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator!=(
+  const Circle& lhs,
+  const Circle& rhs);
+
 } // namespace geometry
 } // namespace rmf_traffic
 

--- a/rmf_traffic/include/rmf_traffic/geometry/Shape.hpp
+++ b/rmf_traffic/include/rmf_traffic/geometry/Shape.hpp
@@ -21,6 +21,7 @@
 
 #include <rmf_utils/impl_ptr.hpp>
 
+#include <functional>
 #include <memory>
 
 namespace rmf_traffic {
@@ -84,6 +85,12 @@ public:
 
   virtual ~FinalShape() = default;
 
+  /// Equality operator
+  bool operator==(const FinalShape& other) const;
+
+  /// Non-equality operator
+  bool operator!=(const FinalShape& other) const;
+
   class Implementation;
 protected:
   FinalShape();
@@ -106,6 +113,20 @@ template<typename T>
 FinalShapePtr make_final(const T& shape)
 {
   return std::make_shared<FinalShape>(shape.finalize());
+}
+
+//==============================================================================
+template<typename T>
+std::function<bool(const Shape& other)> make_equality_comparitor(const T& myself)
+{
+  return [&myself](const Shape& other)
+  {
+    if (const auto* other_derived = dynamic_cast<const T*>(&other))
+    {
+      return myself == *other_derived;
+    }
+    return false;
+  };
 }
 
 } // namespace geometry

--- a/rmf_traffic/include/rmf_traffic/geometry/Space.hpp
+++ b/rmf_traffic/include/rmf_traffic/geometry/Space.hpp
@@ -45,6 +45,30 @@ private:
   rmf_utils::impl_ptr<Implementation> _pimpl;
 };
 
+//==============================================================================
+/// Equality operator for Space objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator==(
+  const Space& lhs,
+  const Space& rhs);
+
+//==============================================================================
+/// Non-equality operator for Space objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator!=(
+  const Space& lhs,
+  const Space& rhs);
+
 } // namespace geometry
 } // namespace rmf_traffic
 

--- a/rmf_traffic/include/rmf_traffic/schedule/Query.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Query.hpp
@@ -465,6 +465,30 @@ Query make_query(
   const Time* start_time,
   const Time* finish_time);
 
+//==============================================================================
+/// Equality operator for Query objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator==(
+  const Query& lhs,
+  const Query& rhs);
+
+//==============================================================================
+/// Non-equality operator for Query objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator!=(
+  const Query& lhs,
+  const Query& rhs);
+
 } // namespace schedule
 
 namespace detail {

--- a/rmf_traffic/src/rmf_traffic/Region.cpp
+++ b/rmf_traffic/src/rmf_traffic/Region.cpp
@@ -228,4 +228,73 @@ template class bidirectional_iterator<
 
 } // namespace detail
 
+//==============================================================================
+bool operator==(
+  const Region& lhs,
+  const Region& rhs)
+{
+  if (lhs.get_map() != rhs.get_map() ||
+    lhs.num_spaces() != rhs.num_spaces())
+  {
+    return false;
+  }
+  if (lhs.get_lower_time_bound() == nullptr)
+  {
+    if (rhs.get_lower_time_bound() != nullptr)
+    {
+      return false;
+    }
+  }
+  else
+  {
+    if (rhs.get_lower_time_bound() == nullptr)
+    {
+      return false;
+    }
+    if (*lhs.get_lower_time_bound() != *rhs.get_lower_time_bound())
+    {
+      return false;
+    }
+  }
+  if (lhs.get_upper_time_bound() == nullptr)
+  {
+    if (rhs.get_upper_time_bound() != nullptr)
+    {
+      return false;
+    }
+  }
+  else
+  {
+    if (rhs.get_upper_time_bound() == nullptr)
+    {
+      return false;
+    }
+    if (*lhs.get_upper_time_bound() != *rhs.get_upper_time_bound())
+    {
+      return false;
+    }
+  }
+
+  auto lhs_it = lhs.begin();
+  auto rhs_it = rhs.begin();
+  while (lhs_it != lhs.end())
+  {
+    if (*lhs_it != *rhs_it)
+    {
+      return false;
+    }
+    ++lhs_it;
+    ++rhs_it;
+  }
+  return true;
+}
+
+//==============================================================================
+bool operator!=(
+  const Region& lhs,
+  const Region& rhs)
+{
+  return !(lhs == rhs);
+}
+
 } // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/geometry/Box.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Box.cpp
@@ -113,7 +113,8 @@ FinalShape Box::finalize() const
     + this->get_y_length() * this->get_y_length());
   return FinalShape::Implementation::make_final_shape(
     rmf_utils::make_derived_impl<const Shape, const Box>(*this),
-    _get_internal()->make_fcl(), characteristic_length);
+    _get_internal()->make_fcl(), characteristic_length,
+    make_equality_comparitor(*this));
 }
 
 //==============================================================================
@@ -124,7 +125,21 @@ FinalConvexShape Box::finalize_convex() const
     + this->get_y_length() * this->get_y_length());
   return FinalConvexShape::Implementation::make_final_shape(
     rmf_utils::make_derived_impl<const Shape, const Box>(*this),
-    _get_internal()->make_fcl(), characteristic_length);
+    _get_internal()->make_fcl(), characteristic_length,
+    make_equality_comparitor(*this));
+}
+
+//==============================================================================
+bool operator==(const Box& lhs, const Box& rhs)
+{
+  return lhs.get_x_length() == rhs.get_x_length() &&
+    lhs.get_y_length() == rhs.get_y_length();
+}
+
+//==============================================================================
+bool operator!=(const Box& lhs, const Box& rhs)
+{
+  return !(lhs == rhs);
 }
 
 } // namespace geometry

--- a/rmf_traffic/src/rmf_traffic/geometry/Box.hpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Box.hpp
@@ -66,6 +66,29 @@ public:
 
 };
 
+//==============================================================================
+/// Equality operator for Box objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator==(
+  const Box& lhs,
+  const Box& rhs);
+
+//==============================================================================
+/// Non-equality operator for Box objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator!=(
+  const Box& lhs,
+  const Box& rhs);
 
 } // namespace geometry
 } // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/geometry/Circle.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Circle.cpp
@@ -92,7 +92,8 @@ FinalShape Circle::finalize() const
 {
   return FinalShape::Implementation::make_final_shape(
     rmf_utils::make_derived_impl<const Shape, const Circle>(*this),
-    _get_internal()->make_fcl(), this->get_radius());
+    _get_internal()->make_fcl(), this->get_radius(),
+    make_equality_comparitor(*this));
 }
 
 //==============================================================================
@@ -100,7 +101,20 @@ FinalConvexShape Circle::finalize_convex() const
 {
   return FinalConvexShape::Implementation::make_final_shape(
     rmf_utils::make_derived_impl<const Shape, const Circle>(*this),
-    _get_internal()->make_fcl(), this->get_radius());
+    _get_internal()->make_fcl(), this->get_radius(),
+    make_equality_comparitor(*this));
+}
+
+//==============================================================================
+bool operator==(const Circle& lhs, const Circle& rhs)
+{
+  return lhs.get_radius() == rhs.get_radius();
+}
+
+//==============================================================================
+bool operator!=(const Circle& lhs, const Circle& rhs)
+{
+  return !(lhs == rhs);
 }
 
 } // namespace geometry

--- a/rmf_traffic/src/rmf_traffic/geometry/Shape.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Shape.cpp
@@ -66,5 +66,17 @@ FinalShape::FinalShape()
   // Implementation::make_final_shape
 }
 
+//==============================================================================
+bool FinalShape::operator==(const FinalShape& other) const
+{
+  return _pimpl->_compare_equality(*(other._pimpl->_shape));
+}
+
+//==============================================================================
+bool FinalShape::operator!=(const FinalShape& other) const
+{
+  return !(*this == other);
+}
+
 } // namespace geometry
 } // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/geometry/ShapeInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/ShapeInternal.hpp
@@ -27,6 +27,7 @@
 #include <fcl/collision_object.h>
 #endif
 
+#include <functional>
 #include <vector>
 
 namespace rmf_traffic {
@@ -63,6 +64,8 @@ public:
 
   double _characteristic_length;
 
+  std::function<bool(const Shape& other)> _compare_equality;
+
   static const CollisionGeometries& get_collisions(const FinalShape& shape)
   {
     return shape._pimpl->_collisions;
@@ -71,13 +74,15 @@ public:
   static FinalShape make_final_shape(
     rmf_utils::impl_ptr<const Shape> shape,
     CollisionGeometries collisions,
-    double characteristic_length)
+    double characteristic_length,
+    std::function<bool(const Shape& other)> compare_equality)
   {
     FinalShape result;
     result._pimpl = rmf_utils::make_impl<Implementation>(
       Implementation{std::move(shape),
         std::move(collisions),
-        std::move(characteristic_length)});
+        std::move(characteristic_length),
+        std::move(compare_equality)});
     return result;
   }
 
@@ -96,13 +101,15 @@ public:
   static FinalConvexShape make_final_shape(
     rmf_utils::impl_ptr<const Shape> shape,
     CollisionGeometries collisions,
-    double characteristic_length)
+    double characteristic_length,
+    std::function<bool(const Shape& other)> compare_equality)
   {
     FinalConvexShape result;
     result._pimpl = rmf_utils::make_impl<FinalShape::Implementation>(
       FinalShape::Implementation{std::move(shape),
         std::move(collisions),
-        characteristic_length});
+        characteristic_length,
+        std::move(compare_equality)});
     return result;
   }
 };

--- a/rmf_traffic/src/rmf_traffic/geometry/SimplePolygon.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/SimplePolygon.cpp
@@ -689,7 +689,33 @@ FinalShape SimplePolygon::finalize() const
   }
   return FinalShape::Implementation::make_final_shape(
     rmf_utils::make_derived_impl<const Shape, const SimplePolygon>(*this),
-    _get_internal()->make_fcl(), characteristic_length);
+    _get_internal()->make_fcl(), characteristic_length,
+    make_equality_comparitor(*this));
+}
+
+//==============================================================================
+bool operator==(const SimplePolygon& lhs, const SimplePolygon& rhs)
+{
+  if (lhs.get_num_points() != rhs.get_num_points())
+  {
+    return false;
+  }
+
+  for (size_t ii = 0; ii < lhs.get_num_points(); ++ii)
+  {
+    if (!lhs.get_point(ii).isApprox(rhs.get_point(ii)))
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+//==============================================================================
+bool operator!=(const SimplePolygon& lhs, const SimplePolygon& rhs)
+{
+  return !(lhs == rhs);
 }
 
 } // namespace geometry

--- a/rmf_traffic/src/rmf_traffic/geometry/SimplePolygon.hpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/SimplePolygon.hpp
@@ -115,6 +115,30 @@ public:
 };
 
 //==============================================================================
+/// Equality operator for SimplePolygon objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator==(
+  const SimplePolygon& lhs,
+  const SimplePolygon& rhs);
+
+//==============================================================================
+/// Non-equality operator for SimplePolygon objects.
+///
+/// \param[in] lhs
+///   A const reference to the left-hand-side of the comparison.
+///
+/// \param[in] rhs
+///   A const reference to the right-hand-side of the comparison.
+bool operator!=(
+  const SimplePolygon& lhs,
+  const SimplePolygon& rhs);
+
+//==============================================================================
 /// \brief If an invalid simple polygon (a polygon having self-intersections or
 /// having less than 3 vertices) is passed into a schedule, this exception will
 /// be raised.

--- a/rmf_traffic/src/rmf_traffic/geometry/Space.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Space.cpp
@@ -64,5 +64,22 @@ Space& Space::set_pose(Eigen::Isometry2d tf)
   return *this;
 }
 
+//==============================================================================
+bool operator==(
+  const Space& lhs,
+  const Space& rhs)
+{
+  return *lhs.get_shape() == *rhs.get_shape() &&
+    lhs.get_pose().isApprox(rhs.get_pose());
+}
+
+//==============================================================================
+bool operator!=(
+  const Space& lhs,
+  const Space& rhs)
+{
+  return !(lhs == rhs);
+}
+
 } // namespace geometry
 } // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -76,7 +76,6 @@ public:
     for (const RouteId id : erase.ids())
     {
       const auto r_it = state.storage.find(id);
-      assert(r_it != state.storage.end());
       if (r_it == state.storage.end())
       {
         std::cerr << "[Mirror::update] Erasing unrecognized route [" << id
@@ -124,7 +123,6 @@ public:
       const RouteId route_id = item.id;
       auto insertion = state.storage.insert({route_id, RouteStorage()});
       const bool inserted = insertion.second;
-      assert(inserted);
       if (!inserted)
       {
         std::cerr << "[Mirror::update] Inserting a route [" << item.id
@@ -315,6 +313,13 @@ Version Mirror::update(const Patch& patch)
       registered.description());
 
     const ParticipantId id = registered.id();
+    // Check if this participant is already known about; if it is, skip it
+    const auto p_it = _pimpl->states.find(id);
+    if (p_it != _pimpl->states.end())
+    {
+      continue;
+    }
+
     const bool inserted = _pimpl->states.insert(
       std::make_pair(
         id,

--- a/rmf_traffic/src/rmf_traffic/schedule/Query.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Query.cpp
@@ -57,6 +57,14 @@ public:
 };
 
 //==============================================================================
+bool operator==(
+  const Query::Spacetime::Regions::Implementation& lhs,
+  const Query::Spacetime::Regions::Implementation& rhs)
+{
+  return lhs.regions == rhs.regions;
+}
+
+//==============================================================================
 class Query::Spacetime::Timespan::Implementation
 {
 public:
@@ -259,6 +267,31 @@ Query::Spacetime::Regions::Regions()
 }
 
 //==============================================================================
+bool operator==(
+  const Query::Spacetime::Regions& lhs,
+  const Query::Spacetime::Regions& rhs)
+{
+  if (lhs.size() != rhs.size())
+  {
+    return false;
+  }
+
+  auto lhs_it = lhs.begin();
+  auto rhs_it = rhs.begin();
+  while (lhs_it != lhs.end() && rhs_it != rhs.end())
+  {
+    if (*lhs_it != *rhs_it)
+    {
+      return false;
+    }
+    ++lhs_it;
+    ++rhs_it;
+  }
+
+  return true;
+}
+
+//==============================================================================
 const std::unordered_set<std::string>&
 Query::Spacetime::Timespan::maps() const
 {
@@ -452,6 +485,40 @@ auto Query::Spacetime::timespan() const -> const Timespan*
 }
 
 //==============================================================================
+bool operator==(
+  const Query::Spacetime::Timespan& lhs,
+  const Query::Spacetime::Timespan& rhs)
+{
+  return lhs.maps() == rhs.maps() &&
+    *lhs.get_lower_time_bound() == *rhs.get_lower_time_bound() &&
+    *lhs.get_upper_time_bound() == *rhs.get_upper_time_bound();
+}
+
+//==============================================================================
+bool operator==(
+  const Query::Spacetime& lhs,
+  const Query::Spacetime& rhs)
+{
+  if (lhs.get_mode() != rhs.get_mode())
+  {
+    return false;
+  }
+
+  switch (lhs.get_mode())
+  {
+    case Query::Spacetime::Mode::All:
+      return true;
+    case Query::Spacetime::Mode::Regions:
+      return *lhs.regions() == *rhs.regions();
+    case Query::Spacetime::Mode::Timespan:
+      return *lhs.timespan() == *rhs.timespan();
+    case Query::Spacetime::Mode::Invalid:
+    default:
+      return false;
+  }
+}
+
+//==============================================================================
 class Query::Participants::Implementation
 {
 public:
@@ -476,6 +543,14 @@ public:
 Query::Participants::All::All()
 {
   // Do nothing
+}
+
+//==============================================================================
+bool operator==(
+  [[maybe_unused]] const Query::Participants::All& lhs,
+  [[maybe_unused]] const Query::Participants::All& rhs)
+{
+  return true;
 }
 
 namespace {
@@ -529,6 +604,14 @@ Query::Participants::Include::Include()
 }
 
 //==============================================================================
+bool operator==(
+  const Query::Participants::Include& lhs,
+  const Query::Participants::Include& rhs)
+{
+  return lhs.get_ids() == rhs.get_ids();
+}
+
+//==============================================================================
 class Query::Participants::Exclude::Implementation
 {
 public:
@@ -563,6 +646,14 @@ auto Query::Participants::Exclude::set_ids(std::vector<ParticipantId> ids)
 Query::Participants::Exclude::Exclude()
 {
   // Do nothing
+}
+
+//==============================================================================
+bool operator==(
+  const Query::Participants::Exclude& lhs,
+  const Query::Participants::Exclude& rhs)
+{
+  return lhs.get_ids() == rhs.get_ids();
 }
 
 //==============================================================================
@@ -673,6 +764,30 @@ auto Query::Participants::exclude(std::vector<ParticipantId> ids)
 }
 
 //==============================================================================
+bool operator==(
+  const Query::Participants& lhs,
+  const Query::Participants& rhs)
+{
+  if (lhs.get_mode() != rhs.get_mode())
+  {
+    return false;
+  }
+
+  switch(lhs.get_mode())
+  {
+    case Query::Participants::Mode::All:
+      return *lhs.all() == *rhs.all();
+    case Query::Participants::Mode::Include:
+      return *lhs.include() == *rhs.include();
+    case Query::Participants::Mode::Exclude:
+      return *lhs.exclude() == *rhs.exclude();
+    case Query::Participants::Mode::Invalid:
+    default:
+      return false;
+  }
+}
+
+//==============================================================================
 class Query::Implementation
 {
 public:
@@ -762,6 +877,23 @@ Query make_query(
 {
   return Query::Implementation::make_query(
     std::move(maps), start_time, finish_time);
+}
+
+//==============================================================================
+bool operator==(
+  const Query& lhs,
+  const Query& rhs)
+{
+  return lhs.spacetime() == rhs.spacetime() &&
+    lhs.participants() == rhs.participants();
+}
+
+//==============================================================================
+bool operator!=(
+  const Query& lhs,
+  const Query& rhs)
+{
+  return !(lhs == rhs);
 }
 
 } // namespace schedule

--- a/rmf_traffic/test/unit/schedule/test_Query.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Query.cpp
@@ -22,7 +22,7 @@
 
 #include <rmf_utils/catch.hpp>
 
-SCENARIO("Test Query API")
+SCENARIO("Test Query API", "[query]")
 {
   using namespace std::chrono_literals;
 
@@ -61,17 +61,157 @@ SCENARIO("Test Query API")
   for (const auto& region : *query.spacetime().regions())
   {
     ++regions;
-    for (const auto& space : region)
+    for ([[maybe_unused]] const auto& space : region)
     {
       ++spaces;
-
-      // TODO(MXG): replace this with [[maybe_unused]] when we can use C++17
-      (void)space;
     }
   }
 
   CHECK(regions == 1);
   CHECK(spaces == 3);
+
+  // Tests for the equality operators.
+  GIVEN("Two queries")
+  {
+    auto now_plus_30s = now + 30s;
+    auto now_plus_1min = now + 1min;
+    // TODO(Geoff): These tests are not exhaustive. Make them so.
+    WHEN("Both queries are empty")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+
+      REQUIRE(query1 == query2);
+    }
+
+    WHEN("Both queries have the same start and end times")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({}, &now, &now_plus_1min);
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({}, &now, &now_plus_1min);
+
+      REQUIRE(query1 == query2);
+    }
+
+    WHEN("The queries have different start times")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({}, &now, &now_plus_1min);
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({}, &now_plus_30s, &now_plus_1min);
+
+      REQUIRE(query1 != query2);
+    }
+
+    WHEN("The queries have different finish times")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({}, &now, &now_plus_30s);
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({}, &now, &now_plus_1min);
+
+      REQUIRE(query1 != query2);
+    }
+
+    WHEN("One query has a spacetime query")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.spacetime().regions()->push_back(
+        rmf_traffic::Region{"test_map", now, now+10s, {}});
+
+      REQUIRE(query1 != query2);
+    }
+
+    WHEN("Both queries have the same spacetime query")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.spacetime().regions()->push_back(
+        rmf_traffic::Region{"test_map", now, now+10s, {}});
+      query2.spacetime().regions()->push_back(
+        rmf_traffic::Region{"test_map", now, now+10s, {}});
+
+      REQUIRE(query1 == query2);
+    }
+
+    WHEN("Both queries have different spacetime queries")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.spacetime().regions()->push_back(
+        rmf_traffic::Region{"test_map", now, now+10s, {}});
+      query2.spacetime().regions()->push_back(
+        rmf_traffic::Region{"another_map", now, now+10s, {}});
+
+      REQUIRE(query1 != query2);
+    }
+
+    WHEN("One query has a participant query")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.participants() = rmf_traffic::schedule::Query::Participants::make_only({1, 2, 3});
+
+      REQUIRE(query1 != query2);
+    }
+
+    WHEN("Both queries have the same participant query")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.participants() = rmf_traffic::schedule::Query::Participants::make_only({1, 2, 3});
+      query2.participants() = rmf_traffic::schedule::Query::Participants::make_only({1, 2, 3});
+
+      REQUIRE(query1 == query2);
+    }
+
+    WHEN("Both queries have different participant queries")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.participants() = rmf_traffic::schedule::Query::Participants::make_only({1, 2, 3});
+      query2.participants() = rmf_traffic::schedule::Query::Participants::make_only({2, 3, 4});
+
+      REQUIRE(query1 != query2);
+
+      rmf_traffic::schedule::Query query3 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query4 =
+        rmf_traffic::schedule::make_query({});
+      query3.participants() = rmf_traffic::schedule::Query::Participants::make_all_except({1, 2, 3});
+      query4.participants() = rmf_traffic::schedule::Query::Participants::make_all_except({2, 3, 4});
+
+      REQUIRE(query3 != query4);
+    }
+
+    WHEN("Both queries have different participant query modes")
+    {
+      rmf_traffic::schedule::Query query1 =
+        rmf_traffic::schedule::make_query({});
+      rmf_traffic::schedule::Query query2 =
+        rmf_traffic::schedule::make_query({});
+      query1.participants() = rmf_traffic::schedule::Query::Participants::make_only({1, 2, 3});
+      query2.participants() = rmf_traffic::schedule::Query::Participants::make_all_except({1, 2, 3});
+
+      REQUIRE(query1 != query2);
+    }
+  }
 
   // TODO(MXG): Write tests for every function to confirm that the
   // Query API works as intended

--- a/rmf_traffic/test/unit/schedule/test_Region.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Region.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <src/rmf_traffic/geometry/Box.hpp>
+
+#include <rmf_traffic/Region.hpp>
+
+#include <rmf_utils/catch.hpp>
+
+SCENARIO("Test Region API", "[region]")
+{
+  using namespace std::chrono_literals;
+
+  auto now = std::chrono::steady_clock::now();
+  const auto box = rmf_traffic::geometry::Box(10.0, 1.0);
+  const auto final_box = rmf_traffic::geometry::make_final_convex(box);
+  Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
+
+  // Tests for the equality operators.
+  // TODO(Geoff): These tests are not exhaustive. Make them so.
+  GIVEN("Two regions")
+  {
+    auto now_plus_30s = now + 30s;
+    auto now_plus_1min = now + 1min;
+
+    WHEN("Both regions are empty")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      CHECK(region1 == region2);
+    }
+
+    WHEN("Regions have different maps")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map2", {});
+
+      CHECK(region1 != region2);
+    }
+
+    WHEN("Regions have the same lower bounds")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      region1.set_lower_time_bound(now_plus_30s);
+      CHECK(region1 != region2);
+
+      region2.set_lower_time_bound(now_plus_30s);
+      CHECK(region1 == region2);
+    }
+
+    WHEN("Regions have different lower bounds")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      region1.set_lower_time_bound(now_plus_30s);
+      CHECK(region1 != region2);
+
+      region2.set_lower_time_bound(now_plus_1min);
+      CHECK(region1 != region2);
+    }
+
+    WHEN("Regions have the same upper bounds")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      region1.set_upper_time_bound(now_plus_30s);
+      CHECK(region1 != region2);
+
+      region2.set_upper_time_bound(now_plus_30s);
+      CHECK(region1 == region2);
+    }
+
+    WHEN("Regions have different upper bounds")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      region1.set_upper_time_bound(now_plus_30s);
+      CHECK(region1 != region2);
+
+      region2.set_upper_time_bound(now_plus_1min);
+      CHECK(region1 != region2);
+    }
+
+    WHEN("Regions have the same spaces")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      region1.push_back(rmf_traffic::geometry::Space{final_box, tf});
+      region2.push_back(rmf_traffic::geometry::Space{final_box, tf});
+
+      CHECK(region1 == region2);
+    }
+
+    WHEN("Regions have different spaces")
+    {
+      rmf_traffic::Region region1("map1", {});
+      rmf_traffic::Region region2("map1", {});
+
+      region1.push_back(rmf_traffic::geometry::Space{final_box, tf});
+      CHECK(region1 != region2);
+
+      tf.rotate(Eigen::Rotation2Dd(90.0*M_PI/180.0));
+      region2.push_back(rmf_traffic::geometry::Space{final_box, tf});
+      CHECK(region1 != region2);
+    }
+  }
+}

--- a/rmf_traffic/test/unit/test_Shape.cpp
+++ b/rmf_traffic/test/unit/test_Shape.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic/geometry/Circle.hpp>
+#include <rmf_traffic/geometry/Shape.hpp>
+#include <src/rmf_traffic/geometry/Box.hpp>
+#include <src/rmf_traffic/geometry/SimplePolygon.hpp>
+
+#include <rmf_utils/catch.hpp>
+
+SCENARIO("Test shapes", "[shape]")
+{
+  // Tests for the equality operators.
+  // TODO(Geoff): These tests are not exhaustive. Make them so.
+  const auto box1 = rmf_traffic::geometry::Box(10.0, 1.0);
+  const auto final_box1 = rmf_traffic::geometry::make_final_convex(box1);
+  const auto box2 = rmf_traffic::geometry::Box(10.0, 1.0);
+  const auto final_box2 = rmf_traffic::geometry::make_final_convex(box2);
+  const auto box3 = rmf_traffic::geometry::Box(10.0, 10.0);
+  const auto final_box3 = rmf_traffic::geometry::make_final_convex(box3);
+
+  CHECK(*final_box1 == *final_box2);
+  CHECK(*final_box1 != *final_box3);
+
+  const auto circle1 = rmf_traffic::geometry::Circle(10.0);
+  const auto final_circle1 = rmf_traffic::geometry::make_final_convex(circle1);
+  const auto circle2 = rmf_traffic::geometry::Circle(10.0);
+  const auto final_circle2 = rmf_traffic::geometry::make_final_convex(circle2);
+  const auto circle3 = rmf_traffic::geometry::Circle(20.0);
+  const auto final_circle3 = rmf_traffic::geometry::make_final_convex(circle3);
+
+  CHECK(*final_circle1 == *final_circle2);
+  CHECK(*final_circle1 != *final_circle3);
+
+  Eigen::Vector2d edge1{10.0, 10.0};
+  Eigen::Vector2d edge2{20.0, 20.0};
+  Eigen::Vector2d edge3{30.0, 30.0};
+  Eigen::Vector2d edge4{40.0, 40.0};
+  Eigen::Vector2d edge5{50.0, 50.0};
+  const auto simple_polygon1 =
+    rmf_traffic::geometry::SimplePolygon({edge1, edge2, edge3});
+  const auto final_simple_polygon1 =
+    rmf_traffic::geometry::make_final(simple_polygon1);
+  const auto simple_polygon2 =
+    rmf_traffic::geometry::SimplePolygon({edge1, edge2, edge3});
+  const auto final_simple_polygon2 =
+    rmf_traffic::geometry::make_final(simple_polygon2);
+  const auto simple_polygon3 =
+    rmf_traffic::geometry::SimplePolygon({edge3, edge4, edge5});
+  const auto final_simple_polygon3 =
+    rmf_traffic::geometry::make_final(simple_polygon3);
+  const auto simple_polygon4 =
+    rmf_traffic::geometry::SimplePolygon({edge2, edge3, edge1});
+  const auto final_simple_polygon4 =
+    rmf_traffic::geometry::make_final(simple_polygon4);
+
+  CHECK(*final_simple_polygon1 == *final_simple_polygon2);
+  CHECK(*final_simple_polygon1 != *final_simple_polygon3);
+  CHECK(*final_simple_polygon1 != *final_simple_polygon4);
+}

--- a/rmf_traffic/test/unit/test_Space.cpp
+++ b/rmf_traffic/test/unit/test_Space.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic/geometry/Circle.hpp>
+#include <rmf_traffic/geometry/Space.hpp>
+
+#include <rmf_utils/catch.hpp>
+
+SCENARIO("Test Space", "[space]")
+{
+  const auto circle1 = rmf_traffic::geometry::Circle(10.0);
+  const auto final_circle1 = rmf_traffic::geometry::make_final_convex(circle1);
+  const auto circle2 = rmf_traffic::geometry::Circle(10.0);
+  const auto final_circle2 = rmf_traffic::geometry::make_final_convex(circle2);
+  const auto circle3 = rmf_traffic::geometry::Circle(20.0);
+  const auto final_circle3 = rmf_traffic::geometry::make_final_convex(circle3);
+
+  Eigen::Isometry2d tf_identity1 = Eigen::Isometry2d::Identity();
+  Eigen::Isometry2d tf_identity2 = Eigen::Isometry2d::Identity();
+  Eigen::Isometry2d tf_90 = Eigen::Isometry2d::Identity();
+  tf_90.rotate(Eigen::Rotation2Dd(90.0*M_PI/180.0));
+
+  GIVEN("Two spaces")
+  {
+    const auto space1 =
+      rmf_traffic::geometry::Space{final_circle1, tf_identity1};
+    const auto space2 =
+      rmf_traffic::geometry::Space{final_circle2, tf_identity2};
+    const auto space3 =
+      rmf_traffic::geometry::Space{final_circle3, tf_identity1};
+    const auto space4 =
+      rmf_traffic::geometry::Space{final_circle1, tf_90};
+    const auto space5 =
+      rmf_traffic::geometry::Space{final_circle3, tf_90};
+    WHEN("Both spaces are the same")
+    {
+      CHECK(space1 == space2);
+    }
+
+    WHEN("Spaces are different")
+    {
+      CHECK(space1 != space3);
+      CHECK(space1 != space4);
+      CHECK(space1 != space5);
+    }
+  }
+}


### PR DESCRIPTION
## New feature implementation

### Implemented feature

The existing method of updating schedule mirrors via a pull-based service request is not scalable to large numbers of mirrors. This group of PRs changes schedule mirroring to use push-based communication via topics.

There are three related PRs that must be merged together:
1. This PR, which makes the mirrors more robust to duplicate changes arriving, at the cost of efficiency (this is a temporary work-around).
2. [rmf_ros2#3](https://github.com/open-rmf/rmf_ros2/pull/3), which adds the topic-based communication functionality.
3. [rmf_internal_msg#3](https://github.com/open-rmf/rmf_internal_msgs/pull/3), which adds the necessary messages.

Additionally, [this PR adding equality comparison for `Query` objects](https://github.com/open-rmf/rmf_traffic/pull/3) is a dependency.

### Implementation description

The schedule node previously provided a service to pull updates from the schedule database. Mirrors would call this service when they wanted the recent changes in the schedule. Usually this was done in response to a broadcast from the schedule node informing them that changes are available; the mirrors would generally sleep until woken by this broadcast.

The functionality added in these PRs changes communication of schedule updates from pull to push. The service and the broadcast changes-available notifier are removed. Instead, when a query is registered with the schedule node, it creates a topic named `query_updates_` with the query ID appended, and responds to the query registration call with the ID of the registered query. The mirror manager node knows to subscribe to the correct topic based on the received query ID, and does so. The schedule node then broadcasts any changes relevant to that query over that topic, allowing the mirror to receive the changes without needing to make a request first.

For further scalability improvements, when a query is registered that is the same as an existing query, the schedule node does not create a new topic. Instead it sends the ID of the existing query. This allows multiple mirrors to listen to the same topic if they are interested in the same query.

To allow a new mirror to receive the entire database even though it joins after some changes have been broadcast, a new mirror joining an existing query will cause the entire database to be re-broadcast to all mirrors of that query. This mostly ensures that all mirrors have all information. However, there are two caveats to this that require temporary workarounds.

1. Delays in topic subscriptions being connected means that sometimes the whole-database message is missed by the new query mirror. This causes it to fail to interpret subsequent individual-change messages, such as a delay message for a participant that it doesn't know about or the erasure of a route that it doesn't have yet. To work around this, encountering an error in interpreting a patch will cause that mirror to request the full database again.
2. Existing mirrors will receive participants, changes, etc. that they already know about. This was previously considered an error. To work around this, these are no longer treated as errors. A log message is output and the duplicate entry is ignored.

These two workarounds will no longer be necessary once how schedules are synchronised is updated to split participant information synchronisation and itinerary information synchronisation. This will be done in a future PR.

### How to test

Start the office demo:

```
ros2 launch rmf_demos office.launch.xml
```

In another terminal, trigger a couple of loop requests:

```
ros2 run rmf_demos_tasks dispatch_loop -s coe -f lounge -n 3 --use_sim_time
```

The schedule should be displayed as normal in `rviz`.

The schedule information flowing over the topic can be verified:

```
ros2 topic echo /rmf_traffic/query_update_1
```

Finally, killing the node that is visualising the schedule in rviz and restarting it should show the schedule disappear when the node is killed and then get displayed again after restarting it.