### PR TITLE
Lane closure

### DIFF
--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package rmf_traffic
 
 1.3.0 (2021-XX-XX)
 ------------------
+* Allow navigation graph lanes to be opened or closed: [#11](https://github.com/open-rmf/rmf_traffic/pull/11)
 * Add persistence to Traffic Schedule Participant IDs: [#242](https://github.com/osrf/rmf_core/pull/242)
 * Allow a minimum plan finish time to be specified: [#307](https://github.com/osrf/rmf_core/pull/307)
 * Check itinerary endpoints when negotiating: [#308](https://github.com/osrf/rmf_core/pull/308)

--- a/rmf_traffic/include/rmf_traffic/agv/LaneClosure.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/LaneClosure.hpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_TRAFFIC__AGV__LANECLOSURE_HPP
+#define RMF_TRAFFIC__AGV__LANECLOSURE_HPP
+
+#include <utility>
+
+#include <rmf_utils/impl_ptr.hpp>
+
+namespace rmf_traffic {
+namespace agv {
+
+//==============================================================================
+/// This class describes the closure status of lanes in a Graph, i.e. whether a
+/// lane is open or closed. Open lanes can be used by the planner to reach a
+/// goal. The planner will not expand down a lane that is closed.
+class LaneClosure
+{
+public:
+
+  /// Default constructor.
+  ///
+  /// By default, all lanes are open.
+  LaneClosure();
+
+  /// Check whether the lane corresponding to the given index is open.
+  ///
+  /// \param[in] lane
+  ///   The index for the lane of interest
+  bool is_open(std::size_t lane) const;
+
+  /// Check whether the lane corresponding to the given index is closed.
+  ///
+  /// \param[in] lane
+  ///   The index for the lane of interest
+  bool is_closed(std::size_t lane) const;
+
+  /// Set the lane corresponding to the given index to be open.
+  ///
+  /// \param[in] lane
+  ///   The index for the opening lane
+  LaneClosure& open(std::size_t lane);
+
+  /// Set the lane corresponding to the given index to be closed.
+  ///
+  /// \param[in] lane
+  ///   The index for the closing lane
+  LaneClosure& close(std::size_t lane);
+
+  /// Get an integer that uniquely describes the overall closure status of the
+  /// graph lanes.
+  std::size_t hash() const;
+
+  /// Equality comparison operator
+  bool operator==(const LaneClosure& other) const;
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+} // namespace agv
+} // namespace rmf_traffic
+
+namespace std {
+//==============================================================================
+template<>
+struct hash<rmf_traffic::agv::LaneClosure>
+{
+  std::size_t operator()(
+    const rmf_traffic::agv::LaneClosure& closure) const noexcept
+  {
+    return closure.hash();
+  }
+};
+} // namespace std
+
+#endif // RMF_TRAFFIC__AGV__LANECLOSURE_HPP
+

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -21,6 +21,7 @@
 #include <rmf_traffic/Trajectory.hpp>
 
 #include <rmf_traffic/agv/Graph.hpp>
+#include <rmf_traffic/agv/LaneClosure.hpp>
 #include <rmf_traffic/agv/Interpolate.hpp>
 #include <rmf_traffic/agv/RouteValidator.hpp>
 #include <rmf_traffic/agv/VehicleTraits.hpp>
@@ -56,6 +57,9 @@ public:
     ///
     /// \param[in] graph
     ///   The graph which is being planned over
+    ///
+    /// \param[in] interpolation
+    ///   The options for how the planner will perform trajectory interpolation
     Configuration(
       Graph graph,
       VehicleTraits traits,
@@ -87,6 +91,16 @@ public:
 
     /// Get a const reference to the interpolation options
     const Interpolate::Options& interpolation() const;
+
+    /// Set the lane closures for the graph. The planner will not attempt to
+    /// expand down any lanes that are closed.
+    Configuration& lane_closures(LaneClosure closures);
+
+    /// Get a mutable reference to the LaneClosure setting
+    LaneClosure& lane_closures();
+
+    /// Get a const reference to the LaneClosure setting
+    const LaneClosure& lane_closures() const;
 
     // TODO(MXG): Add a field to specify whether multi-start planning problems
     // should choose the plan that takes the least amount of time (according to

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -728,6 +728,13 @@ public:
     /// Get the graph index of this Waypoint
     std::optional<std::size_t> graph_index() const;
 
+    /// Get the graph indices of the lanes that will be traversed on the way to
+    /// this Waypoint. This will have multiple values if the robot is able to
+    /// move straight through multiple lanes without stopping to reach this
+    /// Waypoint. It will be empty if the robot does not need to traverse any
+    /// lanes to reach this Waypoint (e.g. it is simply turning in place).
+    const std::vector<std::size_t>& approach_lanes() const;
+
     /// Get the index of the Route in the plan's Itinerary that this Waypoint
     /// belongs to.
     std::size_t itinerary_index() const;

--- a/rmf_traffic/src/rmf_traffic/agv/LaneClosure.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/LaneClosure.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic/agv/LaneClosure.hpp>
+#include <vector>
+
+namespace rmf_traffic {
+namespace agv {
+
+//==============================================================================
+class LaneClosure::Implementation
+{
+public:
+
+  std::vector<std::size_t> bitfield;
+
+  bool contains(std::size_t value) const
+  {
+    const std::size_t bucket = value/sizeof(std::size_t);
+    if (bitfield.size() <= bucket)
+      return false;
+
+
+    const std::size_t compare = 1 << lane;
+    return static_cast<bool>(_pimpl->hash & compare);
+  }
+
+};
+
+//==============================================================================
+bool LaneClosure::is_open(const std::size_t lane) const
+{
+  return !_pimpl->contains(lane);
+}
+
+//==============================================================================
+bool LaneClosure::is_closed(const std::size_t lane) const
+{
+  return _pimpl->contains(lane);
+}
+
+//==============================================================================
+LaneClosure& LaneClosure::open(const std::size_t lane)
+{
+  const std::size_t bit = 1 << lane;
+  _pimpl->hash = (_pimpl->hash & ~bit);
+  return *this;
+}
+
+//==============================================================================
+LaneClosure& LaneClosure::close(std::size_t lane)
+{
+  const std::size_t bit = 1 << lane;
+  _pimpl->hash = (_pimpl->hash | bit);
+  return *this;
+}
+
+//==============================================================================
+std::size_t LaneClosure::hash() const
+{
+  return _pimpl->hash;
+}
+
+//==============================================================================
+bool LaneClosure::operator==(const LaneClosure& other) const
+{
+
+}
+
+} // namespace agv
+} // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/agv/LaneClosure.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/LaneClosure.cpp
@@ -16,7 +16,7 @@
 */
 
 #include <rmf_traffic/agv/LaneClosure.hpp>
-#include <vector>
+#include <unordered_map>
 
 namespace rmf_traffic {
 namespace agv {
@@ -26,25 +26,117 @@ class LaneClosure::Implementation
 {
 public:
 
-  std::vector<std::size_t> bitfield;
-
   bool contains(std::size_t value) const
   {
-    const std::size_t bucket = value/sizeof(std::size_t);
-    if (bitfield.size() <= bucket)
+    assert(field_size == 64);
+    const std::size_t key = _get_key(value);
+    const auto bucket_it = _bitfields.find(key);
+    if (bucket_it == _bitfields.end())
       return false;
 
-
-    const std::size_t compare = 1 << lane;
-    return static_cast<bool>(_pimpl->hash & compare);
+    const std::size_t bit = _get_bit(value);
+    const std::size_t bitfield = bucket_it->second;
+    return static_cast<bool>(bitfield & bit);
   }
 
+  void insert(std::size_t value)
+  {
+    const std::size_t key = _get_key(value);
+    const std::size_t bit = _get_bit(value);
+
+    const auto insertion = _bitfields.insert({key, bit});
+    if (insertion.second)
+    {
+      // The bitfield did not exist before, so now it has been inserted with
+      // the desired bit. We will need to recalculate the hash. After that, we
+      // can return.
+      _recalculate_hash();
+      return;
+    }
+
+    std::size_t& bitfield = insertion.first->second;
+    if (static_cast<bool>(bitfield & bit))
+    {
+      // The map already contained this value, so we do not need to insert it
+      // or recalculate the hash.
+      return;
+    }
+
+    bitfield |= bit;
+    _recalculate_hash();
+  }
+
+  void erase(std::size_t value)
+  {
+    const std::size_t key = _get_key(value);
+    const auto bucket_it = _bitfields.find(key);
+    if (bucket_it == _bitfields.end())
+    {
+      // There was no bitfield for this value, so it is not in the map anyway.
+      // We can simply return here.
+      return;
+    }
+
+    const std::size_t bit = _get_bit(value);
+    std::size_t& bitfield = bucket_it->second;
+    if (!static_cast<bool>(bitfield & bit))
+    {
+      // This bit was not active in the bitfield, so we do not need to do
+      // anything.
+      return;
+    }
+
+    bitfield &= ~bit;
+    _recalculate_hash();
+  }
+
+  std::size_t hash() const
+  {
+    return _hash;
+  }
+
+  bool operator==(const Implementation& other) const
+  {
+    return _bitfields == other._bitfields;
+  }
+
+private:
+
+  std::unordered_map<std::size_t, std::size_t> _bitfields;
+  std::size_t _hash = 0;
+
+  static constexpr std::size_t field_size = sizeof(std::size_t)*8;
+
+  void _recalculate_hash()
+  {
+    _hash = 0;
+    for (const auto& [_, bitfield] : _bitfields)
+      _hash |= bitfield;
+  }
+
+  std::size_t _get_key(const std::size_t value) const
+  {
+    return value/field_size;
+  }
+
+  std::size_t _get_bit(const std::size_t value) const
+  {
+    const std::size_t shift = value % field_size;
+    return std::size_t(1) << shift;
+  }
 };
+
+//==============================================================================
+LaneClosure::LaneClosure()
+: _pimpl(rmf_utils::make_impl<Implementation>())
+{
+  // Do nothing
+}
 
 //==============================================================================
 bool LaneClosure::is_open(const std::size_t lane) const
 {
-  return !_pimpl->contains(lane);
+  return !is_closed(lane);
 }
 
 //==============================================================================
@@ -56,29 +148,27 @@ bool LaneClosure::is_closed(const std::size_t lane) const
 //==============================================================================
 LaneClosure& LaneClosure::open(const std::size_t lane)
 {
-  const std::size_t bit = 1 << lane;
-  _pimpl->hash = (_pimpl->hash & ~bit);
+  _pimpl->erase(lane);
   return *this;
 }
 
 //==============================================================================
 LaneClosure& LaneClosure::close(std::size_t lane)
 {
-  const std::size_t bit = 1 << lane;
-  _pimpl->hash = (_pimpl->hash | bit);
+  _pimpl->insert(lane);
   return *this;
 }
 
 //==============================================================================
 std::size_t LaneClosure::hash() const
 {
-  return _pimpl->hash;
+  return _pimpl->hash();
 }
 
 //==============================================================================
 bool LaneClosure::operator==(const LaneClosure& other) const
 {
-
+  return *_pimpl == *other._pimpl;
 }
 
 } // namespace agv

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -963,6 +963,12 @@ std::optional<std::size_t> Plan::Waypoint::graph_index() const
 }
 
 //==============================================================================
+const std::vector<std::size_t>& Plan::Waypoint::approach_lanes() const
+{
+  return _pimpl->approach_lanes;
+}
+
+//==============================================================================
 std::size_t Plan::Waypoint::itinerary_index() const
 {
   return _pimpl->itinerary_index;

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -37,6 +37,7 @@ public:
   Graph graph;
   VehicleTraits traits;
   Interpolate::Options interpolation;
+  LaneClosure lane_closures;
 
 };
 
@@ -49,7 +50,8 @@ Planner::Configuration::Configuration(
       Implementation{
         std::move(graph),
         std::move(traits),
-        std::move(interpolation)
+        std::move(interpolation),
+        LaneClosure()
       }))
 {
   // Do nothing
@@ -112,6 +114,26 @@ Interpolate::Options& Planner::Configuration::interpolation()
 const Interpolate::Options& Planner::Configuration::interpolation() const
 {
   return _pimpl->interpolation;
+}
+
+//==============================================================================
+auto Planner::Configuration::lane_closures(LaneClosure closures)
+-> Configuration&
+{
+  _pimpl->lane_closures = std::move(closures);
+  return *this;
+}
+
+//==============================================================================
+LaneClosure& Planner::Configuration::lane_closures()
+{
+  return _pimpl->lane_closures;
+}
+
+//==============================================================================
+const LaneClosure& Planner::Configuration::lane_closures() const
+{
+  return _pimpl->lane_closures;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
@@ -36,6 +36,8 @@ public:
 
   rmf_utils::optional<std::size_t> graph_index;
 
+  std::vector<std::size_t> approach_lanes;
+
   std::size_t itinerary_index;
 
   std::size_t trajectory_index;

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -254,10 +254,6 @@ public:
             });
         }
 
-        double entry_cost = 0.0;
-        if (oriented_top != top)
-          entry_cost = oriented_top->info.cost_from_parent;
-
         queue.push(std::move(new_node));
       }
     }
@@ -271,8 +267,6 @@ public:
 
     const Eigen::Vector2d p = top->info.position;
     const double target_yaw = _goal_yaw.value();
-    const Eigen::Vector3d start_position =
-    {p.x(), p.y(), top->info.yaw.value()};
 
     // We assume we will get back a valid factory, because if no rotation is
     // needed, then the planner should have accepted this node earlier.

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -214,6 +214,7 @@ public:
             NodeInfo{
               finishing_entry_opt,
               traversal.finish_waypoint_index,
+              traversal.traversed_lanes,
               next_position,
               target_yaw,
               *remaining_cost_estimate + exit_event_duration,
@@ -242,6 +243,7 @@ public:
               NodeInfo{
                 finish_entry,
                 traversal.finish_waypoint_index,
+                traversal.traversed_lanes,
                 next_position,
                 target_yaw,
                 *remaining_cost_estimate,
@@ -281,6 +283,7 @@ public:
         NodeInfo{
           _goal_entry,
           top->info.waypoint,
+          {},
           p,
           target_yaw,
           0.0,
@@ -386,6 +389,7 @@ public:
             Side::Start
           },
           target_waypoint_index,
+          {},
           p,
           finish_yaw,
           remaining_cost_estimate + event_duration,
@@ -421,6 +425,7 @@ public:
         NodeInfo{
           std::nullopt,
           target_waypoint_index,
+          {},
           oriented_node->info.position,
           oriented_node->info.yaw,
           remaining_cost_estimate,
@@ -534,6 +539,7 @@ auto DifferentialDriveHeuristic::generate(
             key.start_side
           },
           start_waypoint_index,
+          {},
           start_p,
           yaw,
           *start_heuristic,

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveMap.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveMap.hpp
@@ -159,6 +159,7 @@ struct DifferentialDriveMapTypes
     std::optional<Entry> entry;
 
     std::size_t waypoint;
+    std::vector<std::size_t> approach_lanes;
     Eigen::Vector2d position;
     std::optional<double> yaw;
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -1929,6 +1929,7 @@ DifferentialDrivePlanner::DifferentialDrivePlanner(
   _supergraph = Supergraph::make(
     Graph::Implementation::get(_config.graph()),
     _config.vehicle_traits(),
+    _config.lane_closures(),
     _config.interpolation());
 
   _cache = DifferentialDriveHeuristic::make_manager(_supergraph);

--- a/rmf_traffic/src/rmf_traffic/agv/planning/ShortestPathHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/ShortestPathHeuristic.cpp
@@ -99,6 +99,9 @@ public:
 
     for (const auto l : _graph->original().lanes_from[current_wp_index])
     {
+      if (_graph->closures().is_closed(l))
+        continue;
+
       const auto& lane = _graph->original().lanes[l];
       const auto& exit = lane.exit();
       const auto next_waypoint_index = exit.waypoint_index();

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.cpp
@@ -76,6 +76,7 @@ struct TraversalNode
 
   // TODO(MXG): Can std::string_view be used to make this more memory efficient?
   std::vector<std::string> map_names;
+  std::vector<std::size_t> traversed_lanes;
 
   std::array<std::optional<double>, 2> orientations;
   bool standstill = false;
@@ -111,6 +112,7 @@ void node_to_traversals(
   traversal.best_time = 0.0;
   traversal.maps = std::vector<std::string>(
     node.map_names.begin(), node.map_names.end());
+  traversal.traversed_lanes = node.traversed_lanes;
 
 //  std::cout << "Traversal [" << traversal.initial_lane_index << "] -> ("
 //            << traversal.finish_lane_index << "): entry event {"
@@ -260,6 +262,7 @@ void perform_traversal(
     node.initial_lane_index = parent->initial_lane_index;
     node.initial_p = parent->initial_p;
     node.map_names = parent->map_names;
+    node.traversed_lanes = parent->traversed_lanes;
 
     if (parent->entry_event)
       node.entry_event = parent->entry_event->clone();
@@ -273,6 +276,7 @@ void perform_traversal(
       node.entry_event = entry_event->clone();
   }
 
+  node.traversed_lanes.push_back(lane_index);
   node.finish_p = p1;
 
   add_if_missing(node.map_names, wp0.get_map_name());

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
@@ -26,6 +26,7 @@
 #include <rmf_traffic/Route.hpp>
 #include <rmf_traffic/Trajectory.hpp>
 #include <rmf_traffic/agv/VehicleTraits.hpp>
+#include <rmf_traffic/agv/LaneClosure.hpp>
 
 #include <map>
 
@@ -128,10 +129,12 @@ public:
   static std::shared_ptr<const Supergraph> make(
     Graph::Implementation original,
     VehicleTraits traits,
+    LaneClosure lane_closures,
     const Interpolate::Options::Implementation& interpolate);
 
   const Graph::Implementation& original() const;
   const VehicleTraits& traits() const;
+  const LaneClosure& closures() const;
   const Interpolate::Options::Implementation& options() const;
 
   struct FloorChange
@@ -193,10 +196,12 @@ private:
   Supergraph(
     Graph::Implementation original,
     VehicleTraits traits,
+    LaneClosure lane_closures,
     const Interpolate::Options::Implementation& interpolate);
 
   Graph::Implementation _original;
   VehicleTraits _traits;
+  LaneClosure _lane_closures;
   Interpolate::Options::Implementation _interpolate;
   FloorChangeMap _floor_changes;
   std::shared_ptr<const CacheManager<TraversalCache>> _traversals;

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
@@ -65,6 +65,7 @@ struct Traversal
   Graph::Lane::EventPtr entry_event;
   Graph::Lane::EventPtr exit_event;
   std::vector<std::string> maps;
+  std::vector<std::size_t> traversed_lanes;
   double best_time;
 
   struct Alternative

--- a/rmf_traffic/test/unit/agv/planning/test_DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_DifferentialDriveHeuristic.cpp
@@ -234,7 +234,7 @@ SCENARIO("Differential Drive Heuristic -- Peak and Valley")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   auto diff_drive_cache =
     rmf_traffic::agv::planning
@@ -408,7 +408,7 @@ SCENARIO("Differential Drive Heuristic -- Indeterminate Yaw Edge Case")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   // TODO(MXG): Make a cleaner way to instantiate these caches
   using DifferentialDriveCache =

--- a/rmf_traffic/test/unit/agv/planning/test_EuclideanHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_EuclideanHeuristic.cpp
@@ -128,7 +128,6 @@ SCENARIO("Euclidean Heuristic -- Easy Multifloor")
   const Eigen::Vector2d p1 = graph.get_waypoint(1).get_location();
   const Eigen::Vector2d p2 = graph.get_waypoint(2).get_location();
   const Eigen::Vector2d p3 = graph.get_waypoint(3).get_location();
-  const Eigen::Vector2d p7 = graph.get_waypoint(7).get_location();
   const Eigen::Vector2d p8 = graph.get_waypoint(8).get_location();
   const Eigen::Vector2d p11 = graph.get_waypoint(11).get_location();
 

--- a/rmf_traffic/test/unit/agv/planning/test_EuclideanHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_EuclideanHeuristic.cpp
@@ -42,7 +42,7 @@ SCENARIO("Euclidean Heuristic -- Single Floor")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::EuclideanHeuristicFactory> cache_map(
@@ -117,7 +117,7 @@ SCENARIO("Euclidean Heuristic -- Easy Multifloor")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::EuclideanHeuristicFactory> cache_map(
@@ -233,7 +233,7 @@ SCENARIO("Euclidean Heuristic -- Complex Multifloor")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::EuclideanHeuristicFactory> cache_map(
@@ -334,7 +334,7 @@ SCENARIO("Euclidean Heuristic -- No Connection")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::EuclideanHeuristicFactory> cache_map(

--- a/rmf_traffic/test/unit/agv/planning/test_ShortestPathHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_ShortestPathHeuristic.cpp
@@ -50,7 +50,7 @@ SCENARIO("Shortest Path Heuristic -- Single Floor")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::ShortestPathHeuristicFactory> cache_map(
@@ -148,7 +148,7 @@ SCENARIO("Shortest Path Heuristic -- Easy Multifloor")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::ShortestPathHeuristicFactory> cache_map(
@@ -284,7 +284,7 @@ SCENARIO("Shortest Path Heuristic -- Complex Multifloor")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   rmf_traffic::agv::planning::CacheManagerMap<
     rmf_traffic::agv::planning::ShortestPathHeuristicFactory> cache_map(
@@ -390,7 +390,7 @@ SCENARIO("Shortest Path Heuristic -- No Connection")
 
   auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   auto cache_map =
     std::make_optional<rmf_traffic::agv::planning::CacheManagerMap<
@@ -467,7 +467,7 @@ SCENARIO("Shortest Path Heuristic -- No Connection")
 
   supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   // We need to completely reconstruct the cache map, because the supergraph has
   // changed.

--- a/rmf_traffic/test/unit/agv/planning/test_Supergraph.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_Supergraph.cpp
@@ -135,7 +135,7 @@ SCENARIO("Supergraph -- Single Floor, Reversible")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   auto traversals = supergraph->traversals_from(0);
   REQUIRE(traversals);
@@ -260,7 +260,7 @@ SCENARIO("Supergraph -- Single Floor, Events, Irreversible")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   auto traversals = supergraph->traversals_from(0);
   REQUIRE(traversals);

--- a/rmf_traffic/test/unit/agv/planning/test_TranslationHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_TranslationHeuristic.cpp
@@ -90,7 +90,7 @@ SCENARIO("Translation Heuristic")
 
   const auto supergraph = rmf_traffic::agv::planning::Supergraph::make(
     rmf_traffic::agv::Graph::Implementation::get(graph),
-    traits, rmf_traffic::agv::Interpolate::Options());
+    traits, {}, rmf_traffic::agv::Interpolate::Options());
 
   using ShortestPathCache =
     rmf_traffic::agv::planning::CacheManagerMap<

--- a/rmf_traffic/test/unit/agv/test_LaneClosure.cpp
+++ b/rmf_traffic/test/unit/agv/test_LaneClosure.cpp
@@ -31,7 +31,7 @@ SCENARIO("Test LaneClosure class functions")
   {
 //    THEN("All lanes are open")
     {
-      for (std::size_t i=0; i < lane_num; ++i)
+      for (std::size_t i = 0; i < lane_num; ++i)
       {
         CHECK(closure.is_open(i));
         CHECK_FALSE(closure.is_closed(i));
@@ -46,7 +46,7 @@ SCENARIO("Test LaneClosure class functions")
 
 //    THEN("All lanes but 73 are open")
     {
-      for (std::size_t i=0; i < lane_num; ++i)
+      for (std::size_t i = 0; i < lane_num; ++i)
       {
         if (73 == i)
         {
@@ -69,7 +69,7 @@ SCENARIO("Test LaneClosure class functions")
 
 //    THEN("All lanes are open")
     {
-      for (std::size_t i=0; i < lane_num; ++i)
+      for (std::size_t i = 0; i < lane_num; ++i)
       {
         CHECK(closure.is_open(i));
         CHECK_FALSE(closure.is_closed(i));
@@ -138,7 +138,7 @@ SCENARIO("Fuzz test of LaneClosure", "[debug]")
 
   while (closed_lanes.size() > 0)
   {
-    for (std::size_t i=0; i < num_lanes; ++i)
+    for (std::size_t i = 0; i < num_lanes; ++i)
     {
       if (closed_lanes.count(i))
       {
@@ -157,7 +157,7 @@ SCENARIO("Fuzz test of LaneClosure", "[debug]")
     closed_lanes.erase(pop);
   }
 
-  for (std::size_t i=0; i < num_lanes; ++i)
+  for (std::size_t i = 0; i < num_lanes; ++i)
   {
     CHECK(closure.is_open(i));
     CHECK_FALSE(closure.is_closed(i));

--- a/rmf_traffic/test/unit/agv/test_LaneClosure.cpp
+++ b/rmf_traffic/test/unit/agv/test_LaneClosure.cpp
@@ -20,8 +20,9 @@
 #include <rmf_utils/catch.hpp>
 
 #include <unordered_set>
+#include <random>
 
-SCENARIO("Test LaneClosure class")
+SCENARIO("Test LaneClosure class functions")
 {
   rmf_traffic::agv::LaneClosure closure;
   const std::size_t lane_num = 100;
@@ -41,7 +42,7 @@ SCENARIO("Test LaneClosure class")
 //  WHEN("Lane 73 is closed")
   {
     closure.close(73);
-    CHECK(closure.hash() == (1 << 73));
+    CHECK(closure.hash() != 0);
 
 //    THEN("All lanes but 73 are open")
     {
@@ -59,5 +60,106 @@ SCENARIO("Test LaneClosure class")
         }
       }
     }
+  }
+
+//  WHEN("Lane 73 is reopened")
+  {
+    closure.open(73);
+    CHECK(closure.hash() == 0);
+
+//    THEN("All lanes are open")
+    {
+      for (std::size_t i=0; i < lane_num; ++i)
+      {
+        CHECK(closure.is_open(i));
+        CHECK_FALSE(closure.is_closed(i));
+      }
+    }
+  }
+
+  std::unordered_set<rmf_traffic::agv::LaneClosure> unique_closures;
+
+  closure.close(0);
+  CHECK(closure.hash() == 1);
+  CHECK_FALSE(closure.is_open(0));
+  CHECK(closure.is_closed(0));
+
+  unique_closures.insert(closure);
+
+  closure.close(64);
+  {
+    // NOTE(MXG): This is an implementation-specific expectation which can be
+    // relaxed if the implementation of the hash function is ever changed in the
+    // future.
+    CHECK(closure.hash() == 1);
+  }
+  CHECK_FALSE(closure.is_open(0));
+  CHECK(closure.is_closed(0));
+  CHECK_FALSE(closure.is_open(64));
+  CHECK(closure.is_closed(64));
+
+  // Since the value of the closure has changed, it should occupy a new spot in
+  // the set of unique closures, even though its hash has not changed.
+  unique_closures.insert(closure);
+  CHECK(unique_closures.size() == 2);
+
+  closure.open(64);
+  unique_closures.insert(closure);
+  // We should just be inserting the same closure value that we did originally,
+  // so there should still only be 2 closures in the unique set.
+  CHECK(unique_closures.size() == 2);
+}
+
+SCENARIO("Fuzz test of LaneClosure", "[debug]")
+{
+  const std::size_t num_lanes = 150;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<std::size_t> dist(0, num_lanes);
+
+  std::unordered_set<std::size_t> closed_lanes;
+  const std::size_t num_closed_lanes = 10;
+  while (closed_lanes.size() < num_closed_lanes)
+  {
+    closed_lanes.insert(dist(gen));
+  }
+
+  rmf_traffic::agv::LaneClosure closure;
+  std::unordered_set<rmf_traffic::agv::LaneClosure> unique_closures;
+  for (const auto& v : closed_lanes)
+  {
+    unique_closures.insert(closure);
+    closure.close(v);
+  }
+
+  // There should be one unique closure in this set for each lane that we have
+  // closed.
+  CHECK(unique_closures.size() == num_closed_lanes);
+
+  while (closed_lanes.size() > 0)
+  {
+    for (std::size_t i=0; i < num_lanes; ++i)
+    {
+      if (closed_lanes.count(i))
+      {
+        CHECK_FALSE(closure.is_open(i));
+        CHECK(closure.is_closed(i));
+      }
+      else
+      {
+        CHECK(closure.is_open(i));
+        CHECK_FALSE(closure.is_closed(i));
+      }
+    }
+
+    const auto pop = closed_lanes.begin();
+    closure.open(*pop);
+    closed_lanes.erase(pop);
+  }
+
+  for (std::size_t i=0; i < num_lanes; ++i)
+  {
+    CHECK(closure.is_open(i));
+    CHECK_FALSE(closure.is_closed(i));
   }
 }

--- a/rmf_traffic/test/unit/agv/test_LaneClosure.cpp
+++ b/rmf_traffic/test/unit/agv/test_LaneClosure.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic/agv/LaneClosure.hpp>
+
+#include <rmf_utils/catch.hpp>
+
+#include <unordered_set>
+
+SCENARIO("Test LaneClosure class")
+{
+  rmf_traffic::agv::LaneClosure closure;
+  const std::size_t lane_num = 100;
+
+//  WHEN("Default LaneClosure")
+  {
+//    THEN("All lanes are open")
+    {
+      for (std::size_t i=0; i < lane_num; ++i)
+      {
+        CHECK(closure.is_open(i));
+        CHECK_FALSE(closure.is_closed(i));
+      }
+    }
+  }
+
+//  WHEN("Lane 73 is closed")
+  {
+    closure.close(73);
+    CHECK(closure.hash() == (1 << 73));
+
+//    THEN("All lanes but 73 are open")
+    {
+      for (std::size_t i=0; i < lane_num; ++i)
+      {
+        if (73 == i)
+        {
+          CHECK_FALSE(closure.is_open(i));
+          CHECK(closure.is_closed(i));
+        }
+        else
+        {
+          CHECK(closure.is_open(i));
+          CHECK_FALSE(closure.is_closed(i));
+        }
+      }
+    }
+  }
+}

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -3376,21 +3376,25 @@ SCENARIO("Test planning with lane closures")
 
   rmf_traffic::agv::Planner::Configuration configuration{graph, traits};
   std::vector<std::size_t> expected_waypoints;
+  std::vector<std::vector<std::size_t>> expected_lanes;
 
   WHEN("No closures")
   {
     expected_waypoints = {0, 3, 4, 1};
+    expected_lanes = {{}, {}, {0}, {}, {6}, {}, {3}};
   }
 
   WHEN("Close lane 3->4")
   {
     expected_waypoints = {0, 6, 7, 1};
+    expected_lanes = {{}, {}, {0, 10}, {}, {16}, {}, {13, 3}};
     configuration.lane_closures().close(graph.lane_from(3, 4)->index());
   }
 
   WHEN("Close lanes 3->4, 7->4")
   {
     expected_waypoints = {0, 6, 8, 5, 4, 1};
+    expected_lanes = {{}, {}, {0, 10}, {}, {16, 18}, {}, {15}, {}, {9}, {}, {3}};
     configuration.lane_closures()
     .close(graph.lane_from(3, 4)->index())
     .close(graph.lane_from(7, 4)->index());
@@ -3399,6 +3403,7 @@ SCENARIO("Test planning with lane closures")
   WHEN("Close lanes 3->4, 7->4, 5->4")
   {
     expected_waypoints = {};
+    expected_lanes = {};
     configuration.lane_closures()
     .close(graph.lane_from(3, 4)->index())
     .close(graph.lane_from(7, 4)->index())
@@ -3429,5 +3434,9 @@ SCENARIO("Test planning with lane closures")
     CHECK(visited_waypoints.size() == expected_waypoints.size());
     for (const auto& wp : expected_waypoints)
       CHECK(visited_waypoints.count(wp));
+
+    REQUIRE(expected_lanes.size() == result->get_waypoints().size());
+    for (std::size_t i = 0; i < result->get_waypoints().size(); ++i)
+      CHECK(result->get_waypoints()[i].approach_lanes() == expected_lanes[i]);
   }
 }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -3394,7 +3394,9 @@ SCENARIO("Test planning with lane closures")
   WHEN("Close lanes 3->4, 7->4")
   {
     expected_waypoints = {0, 6, 8, 5, 4, 1};
-    expected_lanes = {{}, {}, {0, 10}, {}, {16, 18}, {}, {15}, {}, {9}, {}, {3}};
+    expected_lanes = {
+      {}, {}, {0, 10}, {}, {16, 18}, {}, {15}, {}, {9}, {}, {3}
+    };
     configuration.lane_closures()
     .close(graph.lane_from(3, 4)->index())
     .close(graph.lane_from(7, 4)->index());

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -3392,17 +3392,17 @@ SCENARIO("Test planning with lane closures")
   {
     expected_waypoints = {0, 6, 8, 5, 4, 1};
     configuration.lane_closures()
-      .close(graph.lane_from(3, 4)->index())
-      .close(graph.lane_from(7, 4)->index());
+    .close(graph.lane_from(3, 4)->index())
+    .close(graph.lane_from(7, 4)->index());
   }
 
   WHEN("Close lanes 3->4, 7->4, 5->4")
   {
     expected_waypoints = {};
     configuration.lane_closures()
-      .close(graph.lane_from(3, 4)->index())
-      .close(graph.lane_from(7, 4)->index())
-      .close(graph.lane_from(5, 4)->index());
+    .close(graph.lane_from(3, 4)->index())
+    .close(graph.lane_from(7, 4)->index())
+    .close(graph.lane_from(5, 4)->index());
   }
 
   rmf_traffic::agv::Planner planner(


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This adds a class to track what lanes in a navigation graph are open or closed. Lane closure information is also included in the `rmf_traffic::agv::Planner::Configuration` information, and the planner will refuse to expand down any lane that is closed (except for the start expansion).