### PR TITLE
Allow a Database to be forked off of a Mirror

### DIFF
--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package rmf_traffic
 
 1.3.0 (2021-XX-XX)
 ------------------
+* Allow a Database to be forked off of a Mirror: [#17](https://github.com/open-rmf/rmf_traffic/pull/17)
 * Separate participant descriptions from schedule patches: [#14](https://github.com/open-rmf/rmf_traffic/pull/14)
 * Allow navigation graph lanes to be opened or closed: [#11](https://github.com/open-rmf/rmf_traffic/pull/11)
 * Add persistence to Traffic Schedule Participant IDs: [#242](https://github.com/osrf/rmf_core/pull/242)

--- a/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
@@ -83,6 +83,11 @@ public:
   /// patch does not match
   bool update(const Patch& patch);
 
+  /// Fork a new database off of this Mirror. The state of the new database
+  /// will match the state that the upstream Database had at the time it sent
+  /// the latest Patch.
+  Database fork() const;
+
   // TODO(MXG): Consider a feature to log and report any possible
   // inconsistencies that might show up with the patches, e.g. replacing or
   // erasing a trajectory that was never received in the first place.

--- a/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
@@ -54,7 +54,7 @@ public:
     std::size_t participant_id) const final;
 
   // Documentation inherited from Viewer
-  rmf_utils::optional<Itinerary> get_itinerary(
+  std::optional<Itinerary> get_itinerary(
     std::size_t participant_id) const final;
 
   // Documentation inherited from Viewer

--- a/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
@@ -84,8 +84,8 @@ public:
   bool update(const Patch& patch);
 
   /// Fork a new database off of this Mirror. The state of the new database
-  /// will match the state that the upstream Database had at the time it sent
-  /// the latest Patch.
+  /// will match the last state of the upstream database that this Mirror knows
+  /// about.
   Database fork() const;
 
   // TODO(MXG): Consider a feature to log and report any possible

--- a/rmf_traffic/include/rmf_traffic/schedule/Patch.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Patch.hpp
@@ -45,6 +45,10 @@ public:
     /// \param[in] id
     ///   The ID of the participant that is being changed
     ///
+    /// \param[in] itinerary_version
+    ///   The version of this participant's itinerary that results from applying
+    ///   this patch
+    ///
     /// \param[in] erasures
     ///   The information about which routes to erase
     ///
@@ -55,12 +59,16 @@ public:
     ///   The information about which routes to add
     Participant(
       ParticipantId id,
+      ItineraryVersion itinerary_version,
       Change::Erase erasures,
       std::vector<Change::Delay> delays,
       Change::Add additions);
 
     /// The ID of the participant that this set of changes will patch.
     ParticipantId participant_id() const;
+
+    /// The itinerary version that results from this patch
+    ItineraryVersion itinerary_version() const;
 
     /// The route erasures to perform.
     ///

--- a/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
@@ -144,9 +144,7 @@ public:
   /// This accepts a const-reference to a Database instance. Note that this
   /// class will store a reference to this Database, so its lifecycle is
   /// implicitly dependent on the Database's lifecycle.
-  //
-  // TODO(MXG): Should this demand a std::shared_ptr<Database> instead?
-  DatabaseRectificationRequesterFactory(const Database& database);
+  DatabaseRectificationRequesterFactory(std::shared_ptr<Database> database);
 
   // Documentation inherited
   std::unique_ptr<RectificationRequester> make(
@@ -156,6 +154,10 @@ public:
   /// Call this function to instruct all the RectificationRequestors produced
   /// by this factory to perform their rectifications.
   void rectify();
+
+  /// Change the database that will be getting rectified. This can be used to
+  /// switch to rectifying a new database fork.
+  void change_database(std::shared_ptr<Database> new_database);
 
   class Implementation;
 private:

--- a/rmf_traffic/include/rmf_traffic/schedule/Writer.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Writer.hpp
@@ -40,6 +40,11 @@ public:
   };
 
   using Input = std::vector<Item>;
+  using ParticipantId = rmf_traffic::schedule::ParticipantId;
+  using ParticipantDescription = rmf_traffic::schedule::ParticipantDescription;
+  using ItineraryVersion = rmf_traffic::schedule::ItineraryVersion;
+  using Duration = rmf_traffic::Duration;
+  using RouteId = rmf_traffic::RouteId;
 
   /// Set a brand new itinerary for a participant. This will replace any
   /// itinerary that is already in the schedule for the participant.

--- a/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
@@ -434,10 +434,12 @@ public:
     const auto insertion = participant_ids.insert(new_id);
     if (!insertion.second)
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
         "[Database::Implementation::add_new_participant_id] Re-adding "
         "participant ID [" + std::to_string(new_id) + "]. This should not be "
         "possible! Please report this bug.");
+      // *INDENT-ON*
     }
   }
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
@@ -21,10 +21,9 @@
 #include "ViewerInternal.hpp"
 #include "debug_Database.hpp"
 #include "internal_Snapshot.hpp"
+#include "internal_Database.hpp"
 
 #include "../detail/internal_bidirectional_iterator.hpp"
-
-#include <rmf_traffic/schedule/Database.hpp>
 
 #include <rmf_utils/Modular.hpp>
 
@@ -175,6 +174,15 @@ public:
   std::unordered_set<ParticipantId> participant_ids;
 
   Version schedule_version = 0;
+
+  /// When the Database forked off of a Mirror, this struct will contain
+  /// information about how the mirror was initialized
+  struct ForkInitializationInfo
+  {
+    Version initial_version;
+    Time initial_version_maximum_time;
+  };
+  std::optional<ForkInitializationInfo> fork_info;
 
   struct CullInfo
   {
@@ -418,6 +426,26 @@ public:
     // *INDENT-ON*
   }
 
+  void add_new_participant_id(ParticipantId new_id)
+  {
+    if (rmf_utils::modular(_next_participant_id).less_than_or_equal(new_id))
+      _next_participant_id = new_id + 1;
+
+    const auto insertion = participant_ids.insert(new_id);
+    if (!insertion.second)
+    {
+      throw std::runtime_error(
+        "[Database::Implementation::add_new_participant_id] Re-adding "
+        "participant ID [" + std::to_string(new_id) + "]. This should not be "
+        "possible! Please report this bug.");
+    }
+  }
+
+  static Implementation& get(Database& database)
+  {
+    return *database._pimpl;
+  }
+
 private:
   ParticipantId _next_participant_id = 0;
 };
@@ -441,7 +469,7 @@ std::size_t Database::Debug::current_removed_participant_count(
 }
 
 //==============================================================================
-rmf_utils::optional<Writer::Input> Database::Debug::get_itinerary(
+std::optional<Writer::Input> Database::Debug::get_itinerary(
   const Database& database,
   const ParticipantId participant)
 {
@@ -683,23 +711,22 @@ void Database::erase(
     state.active_routes.erase(id);
 }
 
-//==============================================================================
-Writer::Registration Database::register_participant(
+Writer::Registration register_participant_impl(
+  Database::Implementation& pimpl,
+  ParticipantId id,
   ParticipantDescription description)
 {
-  const ParticipantId id = _pimpl->get_next_participant_id();
+  const Version version = ++pimpl.schedule_version;
   auto tracker = Inconsistencies::Implementation::register_participant(
-    _pimpl->inconsistencies, id);
-
-  const Version version = ++_pimpl->schedule_version;
+    pimpl.inconsistencies, id);
 
   const auto description_ptr =
     std::make_shared<const ParticipantDescription>(std::move(description));
 
-  const auto p_it = _pimpl->states.insert(
+  const auto p_it = pimpl.states.insert(
     std::make_pair(
       id,
-      Implementation::ParticipantState{
+      Database::Implementation::ParticipantState{
         {},
         std::move(tracker),
         {},
@@ -708,15 +735,65 @@ Writer::Registration Database::register_participant(
         version
       })).first;
 
-  _pimpl->descriptions.insert({id, description_ptr});
+  pimpl.descriptions.insert({id, description_ptr});
 
-  _pimpl->add_participant_version[version] = id;
+  pimpl.add_participant_version[version] = id;
 
   const auto& state = p_it->second;
-  return Registration(
+  return Database::Registration(
     id, state.tracker->last_known_version(), state.last_route_id);
 }
 
+//==============================================================================
+Writer::Registration Database::register_participant(
+  ParticipantDescription description)
+{
+  const ParticipantId id = _pimpl->get_next_participant_id();
+  return register_participant_impl(*_pimpl, id, std::move(description));
+}
+
+//==============================================================================
+void internal_register_participant(
+  Database& database,
+  ParticipantId id,
+  ParticipantDescription description)
+{
+  auto& impl = Database::Implementation::get(database);
+  impl.add_new_participant_id(id);
+  register_participant_impl(impl, id, std::move(description));
+}
+
+//==============================================================================
+void set_initial_fork_version(
+  Database& database,
+  Version version)
+{
+  auto& impl = Database::Implementation::get(database);
+  impl.schedule_version = version;
+
+  std::optional<Time> maximum_time;
+  for (const auto& [_, state] : impl.states)
+  {
+    for (const auto& [_, storage] : state.storage)
+    {
+      const auto& route = storage.entry->route;
+      const auto* finish = route->trajectory().finish_time();
+      if (finish)
+      {
+        if (!maximum_time.has_value() || *maximum_time < *finish)
+          maximum_time = *finish;
+      }
+    }
+  }
+
+  if (maximum_time.has_value())
+  {
+    impl.fork_info = Database::Implementation::ForkInitializationInfo{
+      version,
+      *maximum_time
+    };
+  }
+}
 
 //==============================================================================
 void Database::update_description(
@@ -1199,8 +1276,18 @@ auto Database::changes(
   const Query& parameters,
   rmf_utils::optional<Version> after) const -> Patch
 {
+  if (after.has_value() && _pimpl->fork_info.has_value())
+  {
+    // If a specific version is being asked for, but that version predates the
+    // initial version of this forked database, then we will instead simply send
+    // a changeset that will bring the mirrors up to date no matter what their
+    // current version is.
+    if (*after < _pimpl->fork_info->initial_version)
+      return changes(parameters, std::nullopt);
+  }
+
   std::unordered_map<ParticipantId, ParticipantChanges> changes;
-  if (after)
+  if (after.has_value())
   {
     PatchRelevanceInspector inspector(*after);
     _pimpl->timeline.inspect(
@@ -1221,6 +1308,7 @@ auto Database::changes(
   for (const auto& p : changes)
   {
     const auto& changeset = p.second;
+    const auto& state = _pimpl->states.at(p.first);
 
     std::vector<Change::Delay> delays;
     for (const auto& d : changeset.delays)
@@ -1243,6 +1331,7 @@ auto Database::changes(
     part_patches.emplace_back(
       Patch::Participant{
         p.first,
+        state.tracker->last_known_version(),
         Change::Erase(std::move(p.second.erasures)),
         std::move(delays),
         Change::Add(std::move(p.second.additions))
@@ -1321,6 +1410,14 @@ Version Database::cull(Time time)
     Change::Cull(time),
     _pimpl->schedule_version
   };
+
+  if (_pimpl->fork_info.has_value())
+  {
+    // If the initial state of the fork is being culled, then we can erase this
+    // fork initialization information.
+    if (_pimpl->fork_info->initial_version_maximum_time < time)
+      _pimpl->fork_info = std::nullopt;
+  }
 
   return _pimpl->schedule_version;
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -21,6 +21,7 @@
 #include "Timeline.hpp"
 #include "ViewerInternal.hpp"
 #include "internal_Snapshot.hpp"
+#include "internal_Database.hpp"
 
 namespace rmf_traffic {
 namespace schedule {
@@ -45,6 +46,7 @@ public:
   {
     std::unordered_map<RouteId, RouteStorage> storage;
     std::shared_ptr<const ParticipantDescription> description;
+    ItineraryVersion itinerary_version;
   };
 
   // This violates the single-source-of-truth principle, but it helps make it
@@ -316,26 +318,12 @@ void Mirror::update_participants_info(
     if (p_it == _pimpl->states.end())
     {
       // This is a new participant. We need to add a new state entry for it.
+      // We do not add a state for it yet because we know nothing about its
+      // routes or itinerary version.
       const auto description_ptr =
         std::make_shared<const ParticipantDescription>(description);
-      const bool inserted = _pimpl->states.insert(
-        std::make_pair(
-          id,
-          Implementation::ParticipantState{
-            {},
-            description_ptr
-          })).second;
-
       _pimpl->descriptions.insert({id, description_ptr});
       _pimpl->participant_ids.insert(id);
-
-      assert(inserted);
-      if (!inserted)
-      {
-        std::cerr << "[Mirror::update_participants_info] Duplicate participant "
-                  << "ID [" << id << "] while trying to register a new "
-                  << "participant" << std::endl;
-      }
     }
     else
     {
@@ -398,17 +386,14 @@ bool Mirror::update(const Patch& patch)
     const auto insertion = _pimpl->states.insert({participant, {}});
     const auto p_it = insertion.first;
     Implementation::ParticipantState& state = p_it->second;
+    state.itinerary_version = p.itinerary_version();
     const auto newly_inserted = insertion.second;
     if (newly_inserted)
     {
-      // Unknown participant; create an empty participant to store the route
-      // information; a set of participant information has already been
-      // requested as part of registering this mirror with the query.
-      const auto empty_description =
-        std::shared_ptr<const ParticipantDescription>();
-
-      state.description = empty_description;
-      _pimpl->descriptions.insert({participant, empty_description});
+      // Unknown participant. We will create an empty description for it, unless
+      // the description already exists
+      const auto d_it = _pimpl->descriptions.insert({participant, {}}).first;
+      state.description = d_it->second;
       _pimpl->participant_ids.insert(participant);
     }
 
@@ -447,6 +432,29 @@ bool Mirror::update(const Patch& patch)
 
   _pimpl->latest_version = patch.latest_version();
   return true;
+}
+
+//==============================================================================
+Database Mirror::fork() const
+{
+  Database output;
+
+  for (const auto& [id, description] : _pimpl->descriptions)
+    internal_register_participant(output, id, *description);
+
+  for (const auto& [participant, state] : _pimpl->states)
+  {
+    Writer::Input input;
+    input.reserve(state.storage.size());
+    for (const auto& [route_id, route] : state.storage)
+      input.emplace_back(Writer::Item{route_id, route.entry->route});
+
+    output.set(participant, input, state.itinerary_version);
+  }
+
+  set_initial_fork_version(output, _pimpl->latest_version);
+
+  return output;
 }
 
 } // schedule

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -249,12 +249,20 @@ std::shared_ptr<const ParticipantDescription> Mirror::get_participant(
 }
 
 //==============================================================================
-rmf_utils::optional<Itinerary> Mirror::get_itinerary(
+std::optional<Itinerary> Mirror::get_itinerary(
   std::size_t participant_id) const
 {
   const auto p = _pimpl->states.find(participant_id);
   if (p == _pimpl->states.end())
+  {
+    // If we don't have a state, it's possible that we have a description for
+    // this participant but never received a state. In that case we should
+    // return an empty itinerary, not a nullopt.
+    if (_pimpl->participant_ids.count(participant_id) > 0)
+      return {};
+
     return rmf_utils::nullopt;
+  }
 
   const auto& state = p->second;
   Itinerary itinerary;

--- a/rmf_traffic/src/rmf_traffic/schedule/Patch.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Patch.cpp
@@ -27,6 +27,7 @@ class Patch::Participant::Implementation
 public:
 
   ParticipantId id;
+  ItineraryVersion itinerary_version;
   Change::Erase erasures;
   std::vector<Change::Delay> delays;
   Change::Add additions;
@@ -36,12 +37,14 @@ public:
 //==============================================================================
 Patch::Participant::Participant(
   ParticipantId id,
+  ItineraryVersion itinerary_version,
   Change::Erase erasures,
   std::vector<Change::Delay> delays,
   Change::Add additions)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
         id,
+        itinerary_version,
         std::move(erasures),
         std::move(delays),
         std::move(additions)
@@ -54,6 +57,12 @@ Patch::Participant::Participant(
 ParticipantId Patch::Participant::participant_id() const
 {
   return _pimpl->id;
+}
+
+//==============================================================================
+ItineraryVersion Patch::Participant::itinerary_version() const
+{
+  return _pimpl->itinerary_version;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -64,10 +64,10 @@ public:
   };
 
   DatabaseRectificationRequester(
-    const Database& database,
+    std::shared_ptr<std::shared_ptr<Database>> database,
     Rectifier rectifier,
     ParticipantId id)
-  : _database(database),
+  : _database(std::move(database)),
     _handle(std::make_shared<Handle>(Handle{*this})),
     _rectifier(std::move(rectifier)),
     _participant_id(id)
@@ -77,7 +77,7 @@ public:
 
   void rectify()
   {
-    const auto& inconsistencies = _database.inconsistencies();
+    const auto& inconsistencies = (*_database)->inconsistencies();
     for (const auto& p : inconsistencies)
     {
       if (p.participant != _participant_id)
@@ -97,7 +97,7 @@ public:
     }
   }
 
-  const Database& _database;
+  std::shared_ptr<std::shared_ptr<Database>> _database;
   std::shared_ptr<Handle> _handle;
   Rectifier _rectifier;
   ParticipantId _participant_id;
@@ -109,16 +109,16 @@ class DatabaseRectificationRequesterFactory::Implementation
 {
 public:
 
-  const Database& _database;
+  std::shared_ptr<std::shared_ptr<Database>> _database;
   std::vector<std::weak_ptr<DatabaseRectificationRequester::Handle>> _handles;
 
 };
 
 //==============================================================================
 DatabaseRectificationRequesterFactory::DatabaseRectificationRequesterFactory(
-  const Database& database)
+  std::shared_ptr<Database> database)
 : _pimpl(rmf_utils::make_unique_impl<Implementation>(
-      Implementation{database, {}}))
+    Implementation{std::make_shared<std::shared_ptr<Database>>(database), {}}))
 {
   // Do nothing
 }
@@ -155,6 +155,13 @@ void DatabaseRectificationRequesterFactory::rectify()
       handles.end(),
       [](const WeakHandlePtr& h) { return h.expired(); }),
     handles.end());
+}
+
+//==============================================================================
+void DatabaseRectificationRequesterFactory::change_database(
+  std::shared_ptr<Database> new_database)
+{
+  *_pimpl->_database = new_database;
 }
 
 } // namespace schedule

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -118,7 +118,10 @@ public:
 DatabaseRectificationRequesterFactory::DatabaseRectificationRequesterFactory(
   std::shared_ptr<Database> database)
 : _pimpl(rmf_utils::make_unique_impl<Implementation>(
-    Implementation{std::make_shared<std::shared_ptr<Database>>(database), {}}))
+      Implementation{
+        std::make_shared<std::shared_ptr<Database>>(database),
+        {}
+      }))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/debug_Database.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/debug_Database.hpp
@@ -44,7 +44,7 @@ public:
 
   // Returns the itinerary of a participant with given ParticipantId in the form
   // of Writer::Input
-  static rmf_utils::optional<Writer::Input> get_itinerary(
+  static std::optional<Writer::Input> get_itinerary(
     const Database& db,
     const ParticipantId participant);
 

--- a/rmf_traffic/src/rmf_traffic/schedule/internal_Database.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/internal_Database.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_TRAFFIC__SCHEDULE__INTERNAL_DATABASE_HPP
+#define SRC__RMF_TRAFFIC__SCHEDULE__INTERNAL_DATABASE_HPP
+
+#include <rmf_traffic/schedule/Database.hpp>
+
+namespace rmf_traffic {
+namespace schedule {
+
+//==============================================================================
+void internal_register_participant(
+  Database& database,
+  ParticipantId id,
+  ParticipantDescription description);
+
+//==============================================================================
+void set_initial_fork_version(
+  Database& database,
+  Version version);
+
+} // namespace schedule
+} // namespace rmf_traffic
+
+#endif // SRC__RMF_TRAFFIC__SCHEDULE__INTERNAL_DATABASE_HPP

--- a/rmf_traffic/test/unit/schedule/test_Mirror.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Mirror.cpp
@@ -490,9 +490,9 @@ SCENARIO("Testing specialized mirrors")
 }
 
 //==============================================================================
-class FailoverWriter
-  : public rmf_traffic::schedule::Writer,
-    public std::enable_shared_from_this<FailoverWriter>
+class FailoverWriter :
+  public rmf_traffic::schedule::Writer,
+  public std::enable_shared_from_this<FailoverWriter>
 {
 public:
 
@@ -500,8 +500,8 @@ public:
     rmf_traffic::schedule::DatabaseRectificationRequesterFactory;
 
   FailoverWriter()
-    : _database(std::make_shared<rmf_traffic::schedule::Database>()),
-      _rectifiers(std::make_shared<RectFactory>(_database))
+  : _database(std::make_shared<rmf_traffic::schedule::Database>()),
+    _rectifiers(std::make_shared<RectFactory>(_database))
   {
     // Do nothing
   }
@@ -648,7 +648,7 @@ SCENARIO("Test forking off of mirrors")
     "participant",
     "test_Mirror",
     rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-      rmf_traffic::Profile{shape}
+    rmf_traffic::Profile{shape}
   };
 
   auto p0 = writer->make_participant(description);
@@ -782,7 +782,7 @@ SCENARIO("Test forking off of mirrors")
   writer->rectify();
 
   CHECK(rmf_traffic::schedule::Database::Debug::get_itinerary(
-          writer->database(), p0.id())->empty());
+      writer->database(), p0.id())->empty());
 
   // TODO(MXG): This could use more testing. For example, what happens when
   // other mirrors were following the database and then it fails over while


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Now it is possible for a schedule Mirror to fork off a new schedule Database whose state will match the version of the upstream Database that the Mirror is synced with.