### PR TITLE
Check if an endpoint is available before inserting it

### DIFF
--- a/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
@@ -227,12 +227,15 @@ public:
       }
     }
 
-    initial_endpoints.insert(
-      {
-        participant,
-        Endpoint::Implementation::make_initial(participant, initial,
-        description)
-      });
+    if (initial)
+    {
+      initial_endpoints.insert(
+        {
+          participant,
+          Endpoint::Implementation::make_initial(participant, initial,
+          description)
+        });
+    }
   }
 
   static void insert_final_endpoint(
@@ -251,11 +254,14 @@ public:
       }
     }
 
-    final_endpoints.insert(
-      {
-        participant,
-        Endpoint::Implementation::make_final(participant, final, description)
-      });
+    if (final)
+    {
+      final_endpoints.insert(
+        {
+          participant,
+          Endpoint::Implementation::make_final(participant, final, description)
+        });
+    }
   }
 
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

If a negotiation submission is an empty itinerary (which is legal) then there will not be any initial or final endpoint to insert into the negotiation table for that submission. Previously we assumed that the endpoints would always exist, and that could result in a segfault. This PR simply fixes that assumption and checks before inserting them.