### PR TITLE
Fix/missing includes

### DIFF
--- a/rmf_traffic/include/rmf_traffic/blockade/Status.hpp
+++ b/rmf_traffic/include/rmf_traffic/blockade/Status.hpp
@@ -20,7 +20,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <unordered_map>
+#include <optional>
 
 namespace rmf_traffic {
 namespace blockade {

--- a/rmf_traffic/include/rmf_traffic/blockade/Status.hpp
+++ b/rmf_traffic/include/rmf_traffic/blockade/Status.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <unordered_map>
 
 namespace rmf_traffic {
 namespace blockade {

--- a/rmf_traffic/include/rmf_traffic/blockade/Writer.hpp
+++ b/rmf_traffic/include/rmf_traffic/blockade/Writer.hpp
@@ -18,6 +18,7 @@
 #ifndef RMF_TRAFFIC__BLOCKADE__WRITER_HPP
 #define RMF_TRAFFIC__BLOCKADE__WRITER_HPP
 
+#include <vector>
 #include <Eigen/Geometry>
 
 #include <rmf_traffic/Time.hpp>

--- a/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
@@ -18,6 +18,8 @@
 #ifndef RMF_TRAFFIC__SCHEDULE__PARTICIPANTDESCRIPTION_HPP
 #define RMF_TRAFFIC__SCHEDULE__PARTICIPANTDESCRIPTION_HPP
 
+#include<unordered_map>
+
 #include <rmf_traffic/Profile.hpp>
 
 #include <rmf_utils/impl_ptr.hpp>

--- a/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
@@ -18,6 +18,7 @@
 #ifndef RMF_TRAFFIC__SCHEDULE__PARTICIPANTDESCRIPTION_HPP
 #define RMF_TRAFFIC__SCHEDULE__PARTICIPANTDESCRIPTION_HPP
 
+#include <string>
 #include<unordered_map>
 
 #include <rmf_traffic/Profile.hpp>

--- a/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
@@ -19,7 +19,7 @@
 #define RMF_TRAFFIC__SCHEDULE__PARTICIPANTDESCRIPTION_HPP
 
 #include <string>
-#include<unordered_map>
+#include <unordered_map>
 
 #include <rmf_traffic/Profile.hpp>
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
@@ -28,6 +28,7 @@
 #include <rmf_traffic/agv/VehicleTraits.hpp>
 #include <rmf_traffic/agv/LaneClosure.hpp>
 
+#include <array>
 #include <map>
 
 namespace rmf_traffic {

--- a/rmf_traffic/src/rmf_traffic/blockade/Moderator.cpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/Moderator.cpp
@@ -22,6 +22,7 @@
 #include "conflicts.hpp"
 
 #include <list>
+#include <array>
 #include <sstream>
 
 namespace rmf_traffic {

--- a/rmf_traffic/src/rmf_traffic/blockade/geometry.hpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/geometry.hpp
@@ -18,6 +18,7 @@
 #ifndef SRC__RMF_TRAFFIC__BLOCKADE__GEOMETRY_HPP
 #define SRC__RMF_TRAFFIC__BLOCKADE__GEOMETRY_HPP
 
+#include <array>
 #include <Eigen/Geometry>
 
 namespace rmf_traffic {

--- a/rmf_traffic/test/unit/blockade/test_blockade_Moderator.cpp
+++ b/rmf_traffic/test/unit/blockade/test_blockade_Moderator.cpp
@@ -20,6 +20,7 @@
 
 #include <rmf_utils/catch.hpp>
 
+#include <array>
 #include <random>
 
 #include "utils_blockade_scenarios.hpp"

--- a/rmf_traffic/test/unit/blockade/test_blockade_conflicts.cpp
+++ b/rmf_traffic/test/unit/blockade/test_blockade_conflicts.cpp
@@ -20,6 +20,7 @@
 #include "utils_blockade_simulation.hpp"
 #include "utils_blockade_scenarios.hpp"
 
+#include <array>
 #include <iostream>
 
 //==============================================================================

--- a/rmf_traffic/test/unit/blockade/utils_blockade_scenarios.hpp
+++ b/rmf_traffic/test/unit/blockade/utils_blockade_scenarios.hpp
@@ -18,6 +18,7 @@
 #ifndef TEST__UNIT__BLOCKADE__UTILS_BLOCKADE_SCENARIOS_HPP
 #define TEST__UNIT__BLOCKADE__UTILS_BLOCKADE_SCENARIOS_HPP
 
+#include <array>
 #include <rmf_traffic/blockade/Writer.hpp>
 
 //==============================================================================


### PR DESCRIPTION
## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Missing includes that were found only when compiling with `colcon build --mixin clang-libcxx tsan`.