### PR TITLE
Fix participant lifecycles

### DIFF
--- a/rmf_traffic/include/rmf_traffic/debug/Plumber.hpp
+++ b/rmf_traffic/include/rmf_traffic/debug/Plumber.hpp
@@ -47,6 +47,7 @@ private:
   _plumber = std::make_shared<::rmf_traffic::debug::Plumber>(X)
 
 #define CAPTURE_LEAK_HERE \
-  _plumber = std::make_shared<::rmf_traffic::debug::Plumber>(__FILE__":" + std::to_string(__LINE__))
+  _plumber = std::make_shared<::rmf_traffic::debug::Plumber>( \
+    __FILE__ ":" + std::to_string(__LINE__))
 
 #endif // PLUMBER_HPP

--- a/rmf_traffic/include/rmf_traffic/debug/Plumber.hpp
+++ b/rmf_traffic/include/rmf_traffic/debug/Plumber.hpp
@@ -43,4 +43,10 @@ private:
   std::shared_ptr<::rmf_traffic::debug::Plumber> _plumber = \
     std::make_shared<::rmf_traffic::debug::Plumber>(X)
 
+#define CAPTURE_LEAK(X) \
+  _plumber = std::make_shared<::rmf_traffic::debug::Plumber>(X)
+
+#define CAPTURE_LEAK_HERE \
+  _plumber = std::make_shared<::rmf_traffic::debug::Plumber>(__FILE__":" + std::to_string(__LINE__))
+
 #endif // PLUMBER_HPP

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -14,7 +14,7 @@
   <build_depend>libccd-dev</build_depend>
   <build_depend>libfcl-dev</build_depend>
   <!-- Uncomment the line below for fcl-0.6 -->
-  <!-- <build_depend>fcl</build_depend> -->
+  <depend>fcl</depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>rmf_cmake_uncrustify</test_depend>

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -14,7 +14,7 @@
   <build_depend>libccd-dev</build_depend>
   <build_depend>libfcl-dev</build_depend>
   <!-- Uncomment the line below for fcl-0.6 -->
-  <depend>fcl</depend>
+  <!-- <depend>fcl</depend> -->
 
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>rmf_cmake_uncrustify</test_depend>

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
@@ -26,7 +26,7 @@ namespace planning {
 //==============================================================================
 InterfacePtr make_planner_interface(Planner::Configuration config)
 {
-  if (const auto* differential = config.vehicle_traits().get_differential())
+  if (config.vehicle_traits().get_differential())
     return std::make_shared<DifferentialDrivePlanner>(std::move(config));
 
   throw std::runtime_error(

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -52,7 +52,7 @@ struct State
 {
   Conditions conditions;
   Issues issues;
-  std::optional<double> ideal_cost;
+  std::optional<double> ideal_cost = std::nullopt;
 
   class Internal
   {

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -379,7 +379,7 @@ public:
     }
 
     const double rotation_cost = rotation_info.has_value() ?
-          rotation_info->minimum_cost : 0.0;
+      rotation_info->minimum_cost : 0.0;
 
     auto oriented_node =
       std::make_shared<SearchNode>(

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -378,7 +378,9 @@ public:
         _interpolate.rotation_thresh, {initial_map_name});
     }
 
-    const double rotation_cost = rotation_info->minimum_cost;
+    const double rotation_cost = rotation_info.has_value() ?
+          rotation_info->minimum_cost : 0.0;
+
     auto oriented_node =
       std::make_shared<SearchNode>(
       SearchNode{

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
@@ -94,6 +94,12 @@ private:
 template<typename NodePtrT>
 struct DifferentialDriveCompare
 {
+  DifferentialDriveCompare(double threshold = 1e-3)
+  : _threshold(threshold)
+  {
+    // Do nothing
+  }
+
   // Returning False implies that a is preferable to b
   // Returning True implies that b is preferable to a
   bool operator()(const NodePtrT& a, const NodePtrT& b)

--- a/rmf_traffic/src/rmf_traffic/blockade/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/Participant.cpp
@@ -134,7 +134,7 @@ Participant::Implementation::Implementation(
   const ParticipantId id,
   const double radius,
   std::shared_ptr<Writer> writer)
-  : _shared(std::make_shared<Shared>(id, radius, std::move(writer)))
+: _shared(std::make_shared<Shared>(id, radius, std::move(writer)))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/blockade/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/Participant.cpp
@@ -66,6 +66,15 @@ void Participant::Implementation::Shared::check(const Status& status)
 {
   if (status.reservation != _reservation_id)
   {
+    if (!_reservation_id.has_value())
+    {
+      // If _reservation_id is a nullopt, but the blockade moderator believes we
+      // have a reservation, then we should remind the blockade moderator that
+      // we have canceled that reservation.
+      _writer->cancel(_id, status.reservation);
+      return;
+    }
+
     _send_reservation();
 
     if (_last_ready)

--- a/rmf_traffic/src/rmf_traffic/blockade/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/Participant.cpp
@@ -39,16 +39,30 @@ Participant Participant::Implementation::make(
 
   if (rectifier_factory)
   {
-    participant._pimpl->_rectification =
+    participant._pimpl->_shared->_rectification =
       rectifier_factory->make(
-      Rectifier::Implementation::make(*participant._pimpl), participant_id);
+      Rectifier::Implementation::make(
+        participant._pimpl->_shared), participant_id);
   }
 
   return participant;
 }
 
 //==============================================================================
-void Participant::Implementation::check(const Status& status)
+Participant::Implementation::Shared::Shared(
+  const ParticipantId id,
+  const double radius,
+  std::shared_ptr<Writer> writer)
+: _id(id),
+  _writer(std::move(writer)),
+  _reservation_id(std::nullopt),
+  _last_reached(0)
+{
+  _current_reservation.radius = radius;
+}
+
+//==============================================================================
+void Participant::Implementation::Shared::check(const Status& status)
 {
   if (status.reservation != _reservation_id)
   {
@@ -98,7 +112,7 @@ void Participant::Implementation::check(const Status& status)
 }
 
 //==============================================================================
-void Participant::Implementation::check()
+void Participant::Implementation::Shared::check()
 {
   if (!_reservation_id)
     return;
@@ -111,41 +125,39 @@ Participant::Implementation::Implementation(
   const ParticipantId id,
   const double radius,
   std::shared_ptr<Writer> writer)
-: _id(id),
-  _writer(std::move(writer)),
-  _reservation_id(std::nullopt)
+  : _shared(std::make_shared<Shared>(id, radius, std::move(writer)))
 {
-  _current_reservation.radius = radius;
+  // Do nothing
 }
 
 //==============================================================================
-Participant::Implementation::~Implementation()
+Participant::Implementation::Shared::~Shared()
 {
   if (_reservation_id)
     _writer->cancel(_id);
 }
 
 //==============================================================================
-void Participant::Implementation::_send_reservation()
+void Participant::Implementation::Shared::_send_reservation()
 {
   assert(_current_reservation.path.size() > 1);
   _writer->set(_id, _reservation_id.value(), _current_reservation);
 }
 
 //==============================================================================
-void Participant::Implementation::_send_ready()
+void Participant::Implementation::Shared::_send_ready()
 {
   _writer->ready(_id, _reservation_id.value(), _last_ready.value());
 }
 
 //==============================================================================
-void Participant::Implementation::_send_release(CheckpointId checkpoint)
+void Participant::Implementation::Shared::_send_release(CheckpointId checkpoint)
 {
   _writer->release(_id, _reservation_id.value(), checkpoint);
 }
 
 //==============================================================================
-void Participant::Implementation::_send_reached()
+void Participant::Implementation::Shared::_send_reached()
 {
   _writer->reached(_id, _reservation_id.value(), _last_reached);
 }
@@ -153,112 +165,117 @@ void Participant::Implementation::_send_reached()
 //==============================================================================
 void Participant::radius(const double new_radius)
 {
-  _pimpl->_current_reservation.radius = new_radius;
+  _pimpl->_shared->_current_reservation.radius = new_radius;
 }
 
 //==============================================================================
 double Participant::radius() const
 {
-  return _pimpl->_current_reservation.radius;
+  return _pimpl->_shared->_current_reservation.radius;
 }
 
 //==============================================================================
 void Participant::set(std::vector<Writer::Checkpoint> path)
 {
-  _pimpl->_current_reservation.path = std::move(path);
+  const auto& p = _pimpl->_shared;
+  p->_current_reservation.path = std::move(path);
 
-  if (_pimpl->_reservation_id)
-    ++*_pimpl->_reservation_id;
+  if (p->_reservation_id)
+    ++*p->_reservation_id;
   else
-    _pimpl->_reservation_id = 1;
+    p->_reservation_id = 1;
 
-  _pimpl->_last_ready = std::nullopt;
-  _pimpl->_last_reached = 0;
+  p->_last_ready = std::nullopt;
+  p->_last_reached = 0;
 
-  _pimpl->_send_reservation();
+  p->_send_reservation();
 }
 
 //==============================================================================
 const std::vector<Writer::Checkpoint>& Participant::path() const
 {
-  return _pimpl->_current_reservation.path;
+  return _pimpl->_shared->_current_reservation.path;
 }
 
 //==============================================================================
 void Participant::ready(CheckpointId checkpoint)
 {
-  if (_pimpl->_current_reservation.path.size()-1 <= checkpoint)
+  const auto& p = _pimpl->_shared;
+  if (p->_current_reservation.path.size()-1 <= checkpoint)
   {
     // TODO(MXG): Should we consider throwing an exception here?
-    checkpoint = _pimpl->_current_reservation.path.size() - 2;
+    checkpoint = p->_current_reservation.path.size() - 2;
   }
 
-  if (_pimpl->_last_ready.has_value() && checkpoint <= *_pimpl->_last_ready)
+  if (p->_last_ready.has_value() && checkpoint <= *p->_last_ready)
     return;
 
-  _pimpl->_last_ready = checkpoint;
-  _pimpl->_send_ready();
+  p->_last_ready = checkpoint;
+  p->_send_ready();
 }
 
 //==============================================================================
 void Participant::release(CheckpointId checkpoint)
 {
-  if (!_pimpl->_last_ready.has_value())
+  const auto& p = _pimpl->_shared;
+  if (!p->_last_ready.has_value())
     return;
 
-  if (_pimpl->_last_ready.value() < checkpoint)
+  if (p->_last_ready.value() < checkpoint)
     return;
 
   if (checkpoint > 0)
-    _pimpl->_last_ready = checkpoint - 1;
+    p->_last_ready = checkpoint - 1;
   else
-    _pimpl->_last_ready.reset();
+    p->_last_ready.reset();
 
-  _pimpl->_send_release(checkpoint);
+  p->_send_release(checkpoint);
 }
 
 //==============================================================================
 std::optional<CheckpointId> Participant::last_ready() const
 {
-  return _pimpl->_last_ready;
+  return _pimpl->_shared->_last_ready;
 }
 
 //==============================================================================
 void Participant::reached(CheckpointId checkpoint)
 {
-  if (checkpoint <= _pimpl->_last_reached)
+  const auto& p = _pimpl->_shared;
+  if (checkpoint <= p->_last_reached)
     return;
 
-  _pimpl->_last_reached = checkpoint;
-  _pimpl->_send_reached();
+  p->_last_reached = checkpoint;
+  p->_send_reached();
 }
 
 //==============================================================================
 void Participant::cancel()
 {
-  if (_pimpl->_reservation_id)
+  const auto& p = _pimpl->_shared;
+  if (p->_reservation_id)
   {
-    _pimpl->_writer->cancel(_pimpl->_id, *_pimpl->_reservation_id);
-    _pimpl->_reservation_id = std::nullopt;
+    p->_writer->cancel(p->_id, *p->_reservation_id);
+    p->_reservation_id = std::nullopt;
   }
 }
 
 //==============================================================================
 CheckpointId Participant::last_reached() const
 {
-  return _pimpl->_last_reached;
+  return _pimpl->_shared->_last_reached;
 }
 
 //==============================================================================
 ParticipantId Participant::id() const
 {
-  return _pimpl->_id;
+  return _pimpl->_shared->_id;
 }
 
 //==============================================================================
 std::optional<ReservationId> Participant::reservation_id() const
 {
-  return _pimpl->_reservation_id;
+  return _pimpl->_shared->_reservation_id;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/blockade/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/Rectifier.cpp
@@ -26,7 +26,7 @@ namespace blockade {
 
 //==============================================================================
 Rectifier Rectifier::Implementation::make(
-  Participant::Implementation& participant)
+  const std::shared_ptr<Participant::Implementation::Shared>& participant)
 {
   Rectifier output;
   output._pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -38,13 +38,15 @@ Rectifier Rectifier::Implementation::make(
 //==============================================================================
 void Rectifier::check(const Status& status)
 {
-  _pimpl->participant.check(status);
+  if (const auto shared = _pimpl->participant.lock())
+    shared->check(status);
 }
 
 //==============================================================================
 void Rectifier::check()
 {
-  _pimpl->participant.check();
+  if (const auto shared = _pimpl->participant.lock())
+    shared->check();
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/blockade/internal_Participant.hpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/internal_Participant.hpp
@@ -34,33 +34,47 @@ public:
     std::shared_ptr<Writer> writer,
     std::shared_ptr<RectificationRequesterFactory> rectifier_factory);
 
-  void check(const Status& status);
+  class Shared
+  {
+  public:
 
-  void check();
+    Shared(
+      const ParticipantId id,
+      double radius,
+      std::shared_ptr<Writer> writer);
+
+    void check(const Status& status);
+
+    void check();
+
+    ~Shared();
+
+  private:
+    friend class Participant;
+
+    void _send_reservation();
+    void _send_ready();
+    void _send_release(CheckpointId checkpoint);
+    void _send_reached();
+
+    ParticipantId _id;
+    std::shared_ptr<Writer> _writer;
+    std::unique_ptr<RectificationRequester> _rectification;
+
+    Writer::Reservation _current_reservation;
+    std::optional<ReservationId> _reservation_id;
+    std::optional<CheckpointId> _last_ready;
+    CheckpointId _last_reached;
+  };
 
   Implementation(
     ParticipantId id,
     double radius,
     std::shared_ptr<Writer> writer);
 
-  ~Implementation();
-
 private:
   friend class Participant;
-
-  void _send_reservation();
-  void _send_ready();
-  void _send_release(CheckpointId checkpoint);
-  void _send_reached();
-
-  ParticipantId _id;
-  std::shared_ptr<Writer> _writer;
-  std::unique_ptr<RectificationRequester> _rectification;
-
-  Writer::Reservation _current_reservation;
-  std::optional<ReservationId> _reservation_id;
-  std::optional<CheckpointId> _last_ready;
-  CheckpointId _last_reached;
+  std::shared_ptr<Shared> _shared;
 
 };
 

--- a/rmf_traffic/src/rmf_traffic/blockade/internal_Rectifier.hpp
+++ b/rmf_traffic/src/rmf_traffic/blockade/internal_Rectifier.hpp
@@ -30,9 +30,10 @@ class Rectifier::Implementation
 {
 public:
 
-  Participant::Implementation& participant;
+  std::weak_ptr<Participant::Implementation::Shared> participant;
 
-  static Rectifier make(Participant::Implementation& participant);
+  static Rectifier make(
+    const std::shared_ptr<Participant::Implementation::Shared>& participant);
 
 };
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -131,7 +131,7 @@ Participant::Implementation::Implementation(
   ParticipantDescription description,
   std::shared_ptr<Writer> writer)
 : _shared(std::make_shared<Shared>(
-    registration, std::move(description), std::move(writer)))
+      registration, std::move(description), std::move(writer)))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -17,7 +17,7 @@
 
 #include "internal_Participant.hpp"
 #include "debug_Participant.hpp"
-#include "RectifierInternal.hpp"
+#include "internal_Rectifier.hpp"
 
 #include <sstream>
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -15,7 +15,7 @@
  *
 */
 
-#include "ParticipantInternal.hpp"
+#include "internal_Participant.hpp"
 #include "debug_Participant.hpp"
 #include "RectifierInternal.hpp"
 
@@ -27,7 +27,21 @@ namespace schedule {
 //==============================================================================
 ItineraryVersion Participant::Debug::get_itinerary_version(const Participant& p)
 {
-  return p._pimpl->current_version();
+  return p._pimpl->_shared->current_version();
+}
+
+//==============================================================================
+Participant::Implementation::Shared::Shared(
+  const Writer::Registration& registration,
+  ParticipantDescription description,
+  std::shared_ptr<Writer> writer)
+: _id(registration.id()),
+  _version(registration.last_itinerary_version()),
+  _last_route_id(registration.last_route_id()),
+  _description(std::move(description)),
+  _writer(std::move(writer))
+{
+  // Do nothing
 }
 
 //==============================================================================
@@ -44,16 +58,17 @@ Participant Participant::Implementation::make(
 
   if (rectifier_factory)
   {
-    participant._pimpl->_rectification =
+    participant._pimpl->_shared->_rectification =
       rectifier_factory->make(
-      Rectifier::Implementation::make(*participant._pimpl), registration.id());
+      Rectifier::Implementation::make(
+        participant._pimpl->_shared), registration.id());
   }
 
   return participant;
 }
 
 //==============================================================================
-void Participant::Implementation::retransmit(
+void Participant::Implementation::Shared::retransmit(
   const std::vector<Rectifier::Range>& ranges,
   const ItineraryVersion last_known_version)
 {
@@ -105,7 +120,7 @@ void Participant::Implementation::retransmit(
 }
 
 //==============================================================================
-ItineraryVersion Participant::Implementation::current_version() const
+ItineraryVersion Participant::Implementation::Shared::current_version() const
 {
   return _version;
 }
@@ -115,24 +130,21 @@ Participant::Implementation::Implementation(
   const Writer::Registration& registration,
   ParticipantDescription description,
   std::shared_ptr<Writer> writer)
-: _id(registration.id()),
-  _version(registration.last_itinerary_version()),
-  _last_route_id(registration.last_route_id()),
-  _description(std::move(description)),
-  _writer(writer)
+: _shared(std::make_shared<Shared>(
+    registration, std::move(description), std::move(writer)))
 {
   // Do nothing
 }
 
 //==============================================================================
-Participant::Implementation::~Implementation()
+Participant::Implementation::Shared::~Shared()
 {
   // Unregister the participant during destruction
   _writer->unregister_participant(_id);
 }
 
 //==============================================================================
-Writer::Input Participant::Implementation::make_input(
+Writer::Input Participant::Implementation::Shared::make_input(
   std::vector<Route> itinerary)
 {
   Writer::Input input;
@@ -154,7 +166,7 @@ Writer::Input Participant::Implementation::make_input(
 }
 
 //==============================================================================
-ItineraryVersion Participant::Implementation::get_next_version()
+ItineraryVersion Participant::Implementation::Shared::get_next_version()
 {
   return ++_version;
 }
@@ -162,13 +174,15 @@ ItineraryVersion Participant::Implementation::get_next_version()
 //==============================================================================
 RouteId Participant::set(std::vector<Route> itinerary)
 {
+  const auto& p = _pimpl->_shared;
+
   // TODO(MXG): Consider issuing an exception or warning when a single-point
   // trajectory is submitted.
   const auto r_it = std::remove_if(itinerary.begin(), itinerary.end(),
       [](const auto& r) { return r.trajectory().size() < 2; });
   itinerary.erase(r_it, itinerary.end());
 
-  const RouteId initial_route_id = _pimpl->_last_route_id;
+  const RouteId initial_route_id = p->_last_route_id;
   if (itinerary.empty())
   {
     // This situation is more efficient to express as a clear() command
@@ -176,22 +190,27 @@ RouteId Participant::set(std::vector<Route> itinerary)
     return initial_route_id;
   }
 
-  _pimpl->_change_history.clear();
-  _pimpl->_cumulative_delay = std::chrono::seconds(0);
+  p->_change_history.clear();
+  p->_cumulative_delay = std::chrono::seconds(0);
 
-  auto input = _pimpl->make_input(std::move(itinerary));
+  auto input = p->make_input(std::move(itinerary));
 
-  _pimpl->_current_itinerary = input;
+  p->_current_itinerary = input;
 
-  const ItineraryVersion itinerary_version = _pimpl->get_next_version();
-  const ParticipantId id = _pimpl->_id;
+  const ItineraryVersion itinerary_version = p->get_next_version();
+  const ParticipantId id = p->_id;
   auto change =
-    [this, input = std::move(input), itinerary_version, id]()
+    [self = p.get(), input = std::move(input), itinerary_version, id]()
     {
-      this->_pimpl->_writer->set(id, input, itinerary_version);
+      // It should be okay to store the raw pointer of _shared since this
+      // callback should only be accessible by the _shared instance while it's
+      // still alive. Nothing else should be able to touch this callback.
+      // If we find any undefined behavior or seg faults happening near this
+      // code, we should try using a weak_ptr instead of a raw pointer.
+      self->_writer->set(id, input, itinerary_version);
     };
 
-  _pimpl->_change_history[itinerary_version] = change;
+  p->_change_history[itinerary_version] = change;
   change();
 
   return initial_route_id;
@@ -200,27 +219,29 @@ RouteId Participant::set(std::vector<Route> itinerary)
 //==============================================================================
 RouteId Participant::extend(const std::vector<Route>& additional_routes)
 {
-  const RouteId initial_route_id = _pimpl->_last_route_id;
+  const auto& p = _pimpl->_shared;
+
+  const RouteId initial_route_id = p->_last_route_id;
   if (additional_routes.empty())
     return initial_route_id;
 
-  auto input = _pimpl->make_input(std::move(additional_routes));
+  auto input = p->make_input(std::move(additional_routes));
 
-  _pimpl->_current_itinerary.reserve(
-    _pimpl->_current_itinerary.size() + input.size());
+  p->_current_itinerary.reserve(p->_current_itinerary.size() + input.size());
 
   for (const auto& item : input)
-    _pimpl->_current_itinerary.push_back(item);
+    p->_current_itinerary.push_back(item);
 
-  const ItineraryVersion itinerary_version = _pimpl->get_next_version();
-  const ParticipantId id = _pimpl->_id;
+  const ItineraryVersion itinerary_version = p->get_next_version();
+  const ParticipantId id = p->_id;
   auto change =
-    [this, input = std::move(input), itinerary_version, id]()
+    [self = p.get(), input = std::move(input), itinerary_version, id]()
     {
-      this->_pimpl->_writer->extend(id, input, itinerary_version);
+      // See note in Participant::set::[lambda<change>]
+      self->_writer->extend(id, input, itinerary_version);
     };
 
-  _pimpl->_change_history[itinerary_version] = change;
+  p->_change_history[itinerary_version] = change;
   change();
 
   return initial_route_id;
@@ -229,8 +250,10 @@ RouteId Participant::extend(const std::vector<Route>& additional_routes)
 //==============================================================================
 void Participant::delay(Duration delay)
 {
+  const auto& p = _pimpl->_shared;
+
   bool no_delays = true;
-  for (auto& item : _pimpl->_current_itinerary)
+  for (auto& item : p->_current_itinerary)
   {
     if (item.route->trajectory().size() > 0)
     {
@@ -250,38 +273,41 @@ void Participant::delay(Duration delay)
     return;
   }
 
-  _pimpl->_cumulative_delay += delay;
+  p->_cumulative_delay += delay;
 
-  const ItineraryVersion itinerary_version = _pimpl->get_next_version();
-  const ParticipantId id = _pimpl->_id;
+  const ItineraryVersion itinerary_version = p->get_next_version();
+  const ParticipantId id = p->_id;
   auto change =
-    [this, delay, itinerary_version, id]()
+    [self = p.get(), delay, itinerary_version, id]()
     {
-      this->_pimpl->_writer->delay(id, delay, itinerary_version);
+      // See note in Participant::set::[lambda<change>]
+      self->_writer->delay(id, delay, itinerary_version);
     };
 
-  _pimpl->_change_history[itinerary_version] = change;
+  p->_change_history[itinerary_version] = change;
   change();
 }
 
 //==============================================================================
 rmf_traffic::Duration Participant::delay() const
 {
-  return _pimpl->_cumulative_delay;
+  return _pimpl->_shared->_cumulative_delay;
 }
 
 //==============================================================================
 void Participant::erase(const std::unordered_set<RouteId>& input_routes)
 {
+  const auto& p = _pimpl->_shared;
+
   const auto remove_it = std::remove_if(
-    _pimpl->_current_itinerary.begin(),
-    _pimpl->_current_itinerary.end(),
+    p->_current_itinerary.begin(),
+    p->_current_itinerary.end(),
     [&](const Writer::Item& item)
     {
       return input_routes.count(item.id) > 0;
     });
 
-  if (remove_it == _pimpl->_current_itinerary.end())
+  if (remove_it == p->_current_itinerary.end())
   {
     // None of the requested IDs are in the current itinerary, so there is
     // nothing to remove
@@ -290,74 +316,77 @@ void Participant::erase(const std::unordered_set<RouteId>& input_routes)
 
   std::vector<RouteId> routes;
   routes.reserve(input_routes.size());
-  for (auto it = remove_it; it != _pimpl->_current_itinerary.end(); ++it)
+  for (auto it = remove_it; it != p->_current_itinerary.end(); ++it)
     routes.push_back(it->id);
 
-  _pimpl->_current_itinerary.erase(remove_it, _pimpl->_current_itinerary.end());
+  p->_current_itinerary.erase(remove_it, p->_current_itinerary.end());
 
-  const ItineraryVersion itinerary_version = _pimpl->get_next_version();
-  const ParticipantId id = _pimpl->_id;
+  const ItineraryVersion itinerary_version = p->get_next_version();
+  const ParticipantId id = p->_id;
   auto change =
-    [this, routes = std::move(routes), itinerary_version, id]()
+    [self = p.get(), routes = std::move(routes), itinerary_version, id]()
     {
-      this->_pimpl->_writer->erase(id, routes, itinerary_version);
+      // See note in Participant::set::[lambda<change>]
+      self->_writer->erase(id, routes, itinerary_version);
     };
 
-  _pimpl->_change_history[itinerary_version] = change;
+  p->_change_history[itinerary_version] = change;
   change();
 }
 
 //==============================================================================
 void Participant::clear()
 {
-  if (_pimpl->_current_itinerary.empty())
+  const auto& p = _pimpl->_shared;
+
+  if (p->_current_itinerary.empty())
   {
     // There is nothing to clear, so we can skip this change
     return;
   }
 
-  _pimpl->_current_itinerary.clear();
+  p->_current_itinerary.clear();
 
-  const ItineraryVersion itinerary_version = _pimpl->get_next_version();
-  const ParticipantId id = _pimpl->_id;
+  const ItineraryVersion itinerary_version = p->get_next_version();
+  const ParticipantId id = p->_id;
   auto change =
-    [this, itinerary_version, id]()
+    [self = p.get(), itinerary_version, id]()
     {
-      this->_pimpl->_writer->erase(id, itinerary_version);
+      self->_writer->erase(id, itinerary_version);
     };
 
-  _pimpl->_change_history[itinerary_version] = change;
+  p->_change_history[itinerary_version] = change;
   change();
 }
 
 //==============================================================================
 RouteId Participant::last_route_id() const
 {
-  return _pimpl->_last_route_id;
+  return _pimpl->_shared->_last_route_id;
 }
 
 //==============================================================================
 const Writer::Input& Participant::itinerary() const
 {
-  return _pimpl->_current_itinerary;
+  return _pimpl->_shared->_current_itinerary;
 }
 
 //==============================================================================
 ItineraryVersion Participant::version() const
 {
-  return _pimpl->_version;
+  return _pimpl->_shared->_version;
 }
 
 //==============================================================================
 const ParticipantDescription& Participant::description() const
 {
-  return _pimpl->_description;
+  return _pimpl->_shared->_description;
 }
 
 //==============================================================================
 ParticipantId Participant::id() const
 {
-  return _pimpl->_id;
+  return _pimpl->_shared->_id;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -15,7 +15,7 @@
  *
 */
 
-#include "RectifierInternal.hpp"
+#include "internal_Rectifier.hpp"
 
 #include <rmf_traffic/schedule/Database.hpp>
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -24,7 +24,7 @@ namespace schedule {
 
 //==============================================================================
 Rectifier Rectifier::Implementation::make(
-  Participant::Implementation& participant)
+  const std::shared_ptr<Participant::Implementation::Shared>& participant)
 {
   Rectifier rectifier;
   rectifier._pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -38,7 +38,8 @@ void Rectifier::retransmit(
   const std::vector<Range>& ranges,
   ItineraryVersion last_known_version)
 {
-  _pimpl->participant.retransmit(ranges, last_known_version);
+  if (const auto shared = _pimpl->participant.lock())
+    shared->retransmit(ranges, last_known_version);
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/RectifierInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/RectifierInternal.hpp
@@ -19,7 +19,7 @@
 #define SRC__RMF_TRAFFIC__SCHEDULE__RECTIFIERINTERNAL_HPP
 
 #include <rmf_traffic/schedule/Rectifier.hpp>
-#include "ParticipantInternal.hpp"
+#include "internal_Participant.hpp"
 
 namespace rmf_traffic {
 namespace schedule {
@@ -29,9 +29,10 @@ class Rectifier::Implementation
 {
 public:
 
-  Participant::Implementation& participant;
+  std::weak_ptr<Participant::Implementation::Shared> participant;
 
-  static Rectifier make(Participant::Implementation& participant);
+  static Rectifier make(
+    const std::shared_ptr<Participant::Implementation::Shared>& participant);
 
 };
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
@@ -456,21 +456,14 @@ public:
 
     for (const auto& other_entry : other)
     {
-      if (!other_entry)
-      {
-        throw std::runtime_error(
-          "[rmf_traffic::schedule::Timeline::clone_bucket] INTERNAL ERROR: "
-          "nullptr value for bucket entry. Please report this bug to the "
-          "maintainers!");
-      }
-
+      assert(other_entry);
       if (check_relevant)
       {
         if (!check_relevant(*other_entry))
           continue;
       }
 
-      output.emplace_back(std::make_shared<BaseRouteEntry>(*other_entry));
+      output.push_back(std::make_shared<BaseRouteEntry>(*other_entry));
     }
 
     return std::make_shared<BaseBucket>(std::move(output));

--- a/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
@@ -456,6 +456,14 @@ public:
 
     for (const auto& other_entry : other)
     {
+      if (!other_entry)
+      {
+        throw std::runtime_error(
+          "[rmf_traffic::schedule::Timeline::clone_bucket] INTERNAL ERROR: "
+          "nullptr value for bucket entry. Please report this bug to the "
+          "maintainers!");
+      }
+
       if (check_relevant)
       {
         if (!check_relevant(*other_entry))
@@ -504,6 +512,14 @@ public:
   std::shared_ptr<Handle> insert(
     const std::shared_ptr<Entry>& entry)
   {
+    if (!entry)
+    {
+      throw std::runtime_error(
+        "[rmf_traffic::schedule::Timeline::insert] INTERNAL ERROR: "
+        "nullptr value for entry being inserted. Please report this bug to the "
+        "maintainers!");
+    }
+
     std::vector<std::weak_ptr<Bucket>> buckets;
     this->_all_bucket->push_back(entry);
     buckets.emplace_back(this->_all_bucket);

--- a/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
@@ -507,10 +507,12 @@ public:
   {
     if (!entry)
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
         "[rmf_traffic::schedule::Timeline::insert] INTERNAL ERROR: "
         "nullptr value for entry being inserted. Please report this bug to the "
         "maintainers!");
+      // *INDENT-ON*
     }
 
     std::vector<std::weak_ptr<Bucket>> buckets;
@@ -519,11 +521,12 @@ public:
 
     if (entry->route && entry->route->trajectory().size() < 2)
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
-              "[rmf_traffic::schedule::Timeline] Trying to insert a trajectory with "
-              "less than 2 waypoints ["
-              + std::to_string(
-                entry->route->trajectory().size()) + "] is illegal!");
+        "[rmf_traffic::schedule::Timeline] Trying to insert a trajectory with "
+        "less than 2 waypoints ["
+        + std::to_string(entry->route->trajectory().size()) + "] is illegal!");
+      // *INDENT-ON*
     }
 
     if (entry->route && entry->route->trajectory().start_time())

--- a/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
@@ -463,7 +463,7 @@ public:
           continue;
       }
 
-      output.push_back(std::make_shared<BaseRouteEntry>(*other_entry));
+      output.emplace_back(std::make_shared<BaseRouteEntry>(*other_entry));
     }
 
     return std::make_shared<BaseBucket>(std::move(output));

--- a/rmf_traffic/src/rmf_traffic/schedule/internal_Rectifier.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/internal_Rectifier.hpp
@@ -15,8 +15,8 @@
  *
 */
 
-#ifndef SRC__RMF_TRAFFIC__SCHEDULE__RECTIFIERINTERNAL_HPP
-#define SRC__RMF_TRAFFIC__SCHEDULE__RECTIFIERINTERNAL_HPP
+#ifndef SRC__RMF_TRAFFIC__SCHEDULE__INTERNAL_RECTIFIER_HPP
+#define SRC__RMF_TRAFFIC__SCHEDULE__INTERNAL_RECTIFIER_HPP
 
 #include <rmf_traffic/schedule/Rectifier.hpp>
 #include "internal_Participant.hpp"
@@ -39,4 +39,4 @@ public:
 } // namespace schedule
 } // namespace rmf_traffic
 
-#endif // SRC__RMF_TRAFFIC__SCHEDULE__RECTIFIERINTERNAL_HPP
+#endif // SRC__RMF_TRAFFIC__SCHEDULE__INTERNAL_RECTIFIER_HPP


### PR DESCRIPTION
## Bug fix

For multi-threaded use cases, there is a marginal risk that a participant may be destructing at the same time that a rectifier asks it to verify the current state of the database. That race condition can take place even if the ordinary read/write operations on the participant object are tightly controlled, because it can be quite difficult to control when and where (i.e. on which thread) the participant ends up getting destructed.

This PR tweaks the implementation of the participant class so that its internal state is managed by a `std::shared_ptr` which will ensure it does not begin destructing while the rectifier is operating on it.

There are also a few other unrelated memory initialization fixes that are snuck in here.