### PR TITLE
Make the stubborn negotiator's strategy more flexible

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
@@ -189,6 +189,11 @@ public:
     ///   concerned with
     Generator(schedule::Negotiation::Table::ViewerPtr viewer);
 
+    /// Toggle whether to ignore "unresponsive" (also called "read-only")
+    /// schedule participants when determining conflicts. By default, conflicts
+    /// with unresponsive participants will be caught.
+    Generator& ignore_unresponsive(bool val = true);
+
     /// Start with a NegotiatingRouteValidator that will use all the most
     /// preferred alternatives from every participant.
     NegotiatingRouteValidator begin() const;

--- a/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
@@ -169,8 +169,9 @@ public:
     /// This version is safe to use even if the participant being negotiated for
     /// is not in the schedule yet.
     ///
-    /// \param[in] table
-    ///   The Negotiation Table that the generated validators are concerned with
+    /// \param[in] viewer
+    ///   A viewer for the Negotiation Table that the generated validators are
+    ///   concerned with
     ///
     /// \param[in] profile
     ///   The profile of the participant whose routes are being validated.
@@ -184,7 +185,8 @@ public:
     /// profile.
     ///
     /// \param[in] table
-    ///   The Negotiation Table that the generated validators are concerned with
+    ///   A viewer for the Negotiation Table that the generated validators are
+    ///   concerned with
     Generator(schedule::Negotiation::Table::ViewerPtr viewer);
 
     /// Start with a NegotiatingRouteValidator that will use all the most

--- a/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
@@ -194,6 +194,11 @@ public:
     /// with unresponsive participants will be caught.
     Generator& ignore_unresponsive(bool val = true);
 
+    /// Toggle whether to ignore "bystanders" which means schedule participants
+    /// that are not being involved in the negotiation. By default, conflicts
+    /// with bystanders will be caught.
+    Generator& ignore_bystanders(bool val = true);
+
     /// Start with a NegotiatingRouteValidator that will use all the most
     /// preferred alternatives from every participant.
     NegotiatingRouteValidator begin() const;

--- a/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
@@ -56,9 +56,18 @@ public:
   ///   The Participant who wants to be stubborn.
   StubbornNegotiator(std::shared_ptr<const Participant> participant);
 
+  using UpdateVersion = rmf_utils::optional<ItineraryVersion>;
+
   /// Add a set of acceptable wait times.
+  ///
+  /// \param[in] wait_times
+  ///   A list of the wait times that would be accepted for negotiation
+  ///
+  /// \param[in] approval_cb
+  ///   A callback that will be triggered
   StubbornNegotiator& acceptable_waits(
-    std::vector<rmf_traffic::Duration> wait_times);
+    std::vector<rmf_traffic::Duration> wait_times,
+    std::function<UpdateVersion(rmf_traffic::Duration)> approval_cb = nullptr);
 
   void respond(
     const schedule::Negotiation::Table::ViewerPtr& table_viewer,

--- a/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
@@ -64,10 +64,13 @@ public:
   ///   A list of the wait times that would be accepted for negotiation
   ///
   /// \param[in] approval_cb
-  ///   A callback that will be triggered
+  ///   A callback that will be triggered when the negotiator decides that you
+  ///   need to wait for another participant. The callback will receive the
+  ///   chosen wait duration, and is expected to return the schedule version
+  ///   that will incorporate the given wait time.
   StubbornNegotiator& acceptable_waits(
-    std::vector<rmf_traffic::Duration> wait_times,
-    std::function<UpdateVersion(rmf_traffic::Duration)> approval_cb = nullptr);
+    std::vector<Duration> wait_times,
+    std::function<UpdateVersion(Duration wait_time)> approval_cb = nullptr);
 
   /// Add some timing margins that will be put into the negotiation submission.
   /// This effectively asks other robots to back off somewhat.

--- a/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
@@ -56,6 +56,10 @@ public:
   ///   The Participant who wants to be stubborn.
   StubbornNegotiator(std::shared_ptr<const Participant> participant);
 
+  /// Add a set of acceptable wait times.
+  StubbornNegotiator& acceptable_waits(
+    std::vector<rmf_traffic::Duration> wait_times);
+
   void respond(
     const schedule::Negotiation::Table::ViewerPtr& table_viewer,
     const ResponderPtr& responder) final;

--- a/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
@@ -139,7 +139,7 @@ class NegotiatingRouteValidator::Generator::Implementation
 public:
   struct Data
   {
-    std::unordered_set<schedule::ParticipantId> cohorts;
+    std::unordered_set<schedule::ParticipantId> stakeholders;
     schedule::Negotiation::Table::ViewerPtr viewer;
     Profile profile;
     bool ignore_unresponsive;
@@ -149,14 +149,14 @@ public:
   std::shared_ptr<Data> data;
   std::vector<schedule::ParticipantId> alternative_sets;
 
-  static std::unordered_set<schedule::ParticipantId> get_cohorts(
+  static std::unordered_set<schedule::ParticipantId> get_stakeholders(
     const schedule::Negotiation::Table::ViewerPtr& viewer)
   {
-    std::unordered_set<schedule::ParticipantId> cohorts;
+    std::unordered_set<schedule::ParticipantId> stakeholders;
     for (const auto& p : viewer->sequence())
-      cohorts.insert(p.participant);
+      stakeholders.insert(p.participant);
 
-    return cohorts;
+    return stakeholders;
   }
 
   Implementation(
@@ -164,7 +164,7 @@ public:
     Profile profile)
   : data(std::make_shared<Data>(
         Data{
-          get_cohorts(viewer),
+          get_stakeholders(viewer),
           std::move(viewer),
           std::move(profile),
           false,
@@ -439,7 +439,7 @@ NegotiatingRouteValidator::find_conflict(const Route& route) const
     if (!data->ignore_bystanders)
       return false;
 
-    return data->cohorts.find(id) == data->cohorts.end();
+    return data->stakeholders.find(id) == data->stakeholders.end();
   };
 
   const auto skip_participant =

--- a/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
@@ -424,37 +424,37 @@ NegotiatingRouteValidator::find_conflict(const Route& route) const
 
   const auto skip_unresponsive =
     [may_skip = _pimpl->data->ignore_unresponsive](
-      const schedule::ParticipantDescription& description) -> bool
-  {
-    if (!may_skip)
-      return false;
+    const schedule::ParticipantDescription& description) -> bool
+    {
+      if (!may_skip)
+        return false;
 
-    return description.responsiveness()
-      == schedule::ParticipantDescription::Rx::Unresponsive;
-  };
+      return description.responsiveness()
+        == schedule::ParticipantDescription::Rx::Unresponsive;
+    };
 
   const auto skip_bystander =
     [data = _pimpl->data](const schedule::ParticipantId id) -> bool
-  {
-    if (!data->ignore_bystanders)
-      return false;
+    {
+      if (!data->ignore_bystanders)
+        return false;
 
-    return data->stakeholders.find(id) == data->stakeholders.end();
-  };
+      return data->stakeholders.find(id) == data->stakeholders.end();
+    };
 
   const auto skip_participant =
     [skip_unresponsive, skip_bystander](
-      const schedule::ParticipantId id,
-      const schedule::ParticipantDescription& desc) -> bool
-  {
-    if (skip_unresponsive(desc))
-      return true;
+    const schedule::ParticipantId id,
+    const schedule::ParticipantDescription& desc) -> bool
+    {
+      if (skip_unresponsive(desc))
+        return true;
 
-    if (skip_bystander(id))
-      return true;
+      if (skip_bystander(id))
+        return true;
 
-    return false;
-  };
+      return false;
+    };
 
   const auto view = _pimpl->data->viewer->query(spacetime, _pimpl->rollouts);
   for (const auto& v : view)

--- a/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
@@ -28,13 +28,14 @@ public:
 
   const Participant* participant;
   std::shared_ptr<const Participant> shared_ref;
+  std::vector<rmf_traffic::Duration> acceptable_waits;
 
 };
 
 //==============================================================================
 StubbornNegotiator::StubbornNegotiator(const Participant& participant)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-      Implementation{&participant, nullptr}))
+      Implementation{&participant, nullptr, {}}))
 {
   // Do nothing
 }
@@ -43,9 +44,17 @@ StubbornNegotiator::StubbornNegotiator(const Participant& participant)
 StubbornNegotiator::StubbornNegotiator(
   std::shared_ptr<const Participant> participant)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-      Implementation{participant.get(), participant}))
+      Implementation{participant.get(), participant, {}}))
 {
   // Do nothing
+}
+
+//==============================================================================
+StubbornNegotiator& StubbornNegotiator::acceptable_waits(
+  std::vector<rmf_traffic::Duration> wait_times)
+{
+  _pimpl->acceptable_waits = std::move(wait_times);
+  return *this;
 }
 
 //==============================================================================
@@ -53,13 +62,36 @@ void StubbornNegotiator::respond(
   const schedule::Negotiation::Table::ViewerPtr& table_viewer,
   const ResponderPtr& responder)
 {
-  if (table_viewer->rejected())
-  {
-    // If one of our proposals has been rejected, then all we can do is forfeit.
-    return responder->forfeit({});
-  }
+  std::vector<rmf_traffic::Route> submission;
 
   const auto& itinerary = _pimpl->participant->itinerary();
+  for (const auto& item : itinerary)
+    submission.push_back(*item.route);
+
+  const auto table_version = table_viewer->sequence().back().version;
+  if (table_viewer->rejected() && table_version > 0)
+  {
+    const auto wait_index = table_version - 1;
+    if (wait_index < _pimpl->acceptable_waits.size())
+    {
+      const auto wait = _pimpl->acceptable_waits[wait_index];
+      for (auto& item : submission)
+        item.trajectory().front().adjust_times(wait);
+
+      const auto& first_wp = submission.front().trajectory().front();
+      submission.front().trajectory().insert(
+        first_wp.time() - wait,
+        first_wp.position(),
+        Eigen::Vector3d::Zero());
+    }
+    else
+    {
+      // If we can't come up with an itinerary that hasn't been rejected, then we
+      // must forfeit.
+      return responder->forfeit({});
+    }
+  }
+
   const auto& profile = _pimpl->participant->description().profile();
   const auto& proposal = table_viewer->base_proposals();
 
@@ -71,31 +103,30 @@ void StubbornNegotiator::respond(
 
     for (const auto& other_route : p.itinerary)
     {
-      for (const auto& item : itinerary)
+      for (const auto& item : submission)
       {
-        if (item.route->map() != other_route->map())
+        if (item.map() != other_route->map())
           continue;
 
         if (rmf_traffic::DetectConflict::between(
             profile,
-            item.route->trajectory(),
+            item.trajectory(),
             other_profile,
             other_route->trajectory()))
         {
           rmf_traffic::schedule::Itinerary alternative;
-          alternative.reserve(itinerary.size());
-          for (const auto& item : itinerary)
-            alternative.emplace_back(item.route);
+          alternative.reserve(submission.size());
+          for (const auto& item : submission)
+          {
+            alternative.emplace_back(
+              std::make_shared<rmf_traffic::Route>(item));
+          }
 
           return responder->reject({std::move(alternative)});
         }
       }
     }
   }
-
-  std::vector<rmf_traffic::Route> submission;
-  for (const auto& item : itinerary)
-    submission.push_back(*item.route);
 
   responder->submit(std::move(submission));
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
@@ -171,15 +171,15 @@ void StubbornNegotiator::respond(
 
   auto generator =
     rmf_traffic::agv::NegotiatingRouteValidator::Generator(
-      table_viewer, _pimpl->participant->description().profile())
-      .ignore_unresponsive()
-      .ignore_bystanders();
+    table_viewer, _pimpl->participant->description().profile())
+    .ignore_unresponsive()
+    .ignore_bystanders();
 
   std::vector<rmf_traffic::schedule::Itinerary> alternatives;
   for (const auto& validator : generator.all())
   {
     if (_pimpl->test_candidate(0s, original, *validator, alternatives)
-        .has_value())
+      .has_value())
     {
       responder->submit(
         add_margins(original, _pimpl->margins),

--- a/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
@@ -127,7 +127,8 @@ void StubbornNegotiator::respond(
   auto generator =
     rmf_traffic::agv::NegotiatingRouteValidator::Generator(
       table_viewer, _pimpl->participant->description().profile())
-      .ignore_unresponsive();
+      .ignore_unresponsive()
+      .ignore_bystanders();
 
   std::vector<rmf_traffic::schedule::Itinerary> alternatives;
   for (const auto& validator : generator.all())
@@ -177,8 +178,8 @@ void StubbornNegotiator::respond(
   {
     if (table_viewer->sequence().size() <= 1)
     {
-      // If this is the first participant in the negotiation sequence, then we
-      // need to forfeit, because there is no lower level proposal to reject.
+      // We have been rejected too many times, and we have no parent to reject.
+      // Let's just forfeit.
       responder->forfeit({});
     }
 

--- a/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
@@ -123,7 +123,8 @@ void StubbornNegotiator::respond(
 
   auto generator =
     rmf_traffic::agv::NegotiatingRouteValidator::Generator(
-      table_viewer, _pimpl->participant->description().profile());
+      table_viewer, _pimpl->participant->description().profile())
+      .ignore_unresponsive();
 
   std::vector<rmf_traffic::schedule::Itinerary> alternatives;
   for (const auto& validator : generator.all())


### PR DESCRIPTION
The `StubbornNegotiator` negotiation strategy may be too rigid to be a good fit for some tricky circumstances. This PR provides more knobs to tailor the strategy of a `StubbornNegotiator` to better suit various circumstances.

These changes are particularly important if multiple read-only traffic participants need to co-exist in the same space. The new stubborn negotiation options allows conflicts between read-only participants to be resolved outside of RMF (e.g. by human operators) while still resolving any conflicts between the read-only and autonomous participants.