### PR TITLE
Add lane speed limits to the graph and factor them into the planning

### DIFF
--- a/rmf_traffic/CHANGELOG.md
+++ b/rmf_traffic/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for package rmf_traffic
 
+Upcoming
+------------------
+* Support lane speed limits: [#44](https://github.com/open-rmf/rmf_traffic/pull/44)
+
 1.4.0 (2021-09-01)
 ------------------
 * Mandate use of FCL>=0.6: [#39](https://github.com/open-rmf/rmf_traffic/pull/39)

--- a/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
@@ -437,6 +437,30 @@ public:
       rmf_utils::impl_ptr<Implementation> _pimpl;
     };
 
+
+    /// The Lane Properties class contains properties that apply across the full
+    /// extent of the lane.
+    class Properties
+    {
+    public:
+
+      /// Construct a default set of properties
+      /// * speed_limit: nullopt
+      Properties();
+
+      /// Get the speed limit along this lane. If a std::nullopt is returned,
+      /// then there is no specified speed limit for the lane.
+      std::optional<double> speed_limit() const;
+
+      /// Set the speed limit along this lane. Providing a std::nullopt
+      /// indicates that there is no speed limit for the lane.
+      Properties& speed_limit(std::optional<double> value);
+
+      class Implementation;
+    private:
+      rmf_utils::impl_ptr<Implementation> _pimpl;
+    };
+
     /// Get the entry node of this Lane. The lane represents an edge in the
     /// graph that goes away from this node.
     Node& entry();
@@ -450,6 +474,12 @@ public:
 
     /// const-qualified exit()
     const Node& exit() const;
+
+    /// Get the properties of this Lane
+    Properties& properties();
+
+    /// const-qualified properties()
+    const Properties& properties() const;
 
     /// Get the index of this Lane within the Graph.
     std::size_t index() const;
@@ -511,7 +541,8 @@ public:
   /// graph to know how the robot is allowed to traverse between waypoints.
   Lane& add_lane(
     const Lane::Node& entry,
-    const Lane::Node& exit);
+    const Lane::Node& exit,
+    Lane::Properties properties = Lane::Properties());
 
   /// Get the lane at the specified index
   Lane& get_lane(std::size_t index);

--- a/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
@@ -646,6 +646,36 @@ auto Graph::Lane::Node::orientation_constraint() const
 }
 
 //==============================================================================
+class Graph::Lane::Properties::Implementation
+{
+public:
+
+  std::optional<double> speed_limit;
+
+};
+
+//==============================================================================
+Graph::Lane::Properties::Properties()
+: _pimpl(rmf_utils::make_impl<Implementation>())
+{
+  // Do nothing
+}
+
+//==============================================================================
+std::optional<double> Graph::Lane::Properties::speed_limit() const
+{
+  return _pimpl->speed_limit;
+}
+
+//==============================================================================
+auto Graph::Lane::Properties::speed_limit(std::optional<double> value)
+-> Properties&
+{
+  _pimpl->speed_limit = value;
+  return *this;
+}
+
+//==============================================================================
 class Graph::Lane::Implementation
 {
 public:
@@ -656,8 +686,7 @@ public:
 
   Node exit;
 
-  bool has_door;
-  std::size_t door_index;
+  Properties properties;
 
   template<typename... Args>
   static Lane make(Args&& ... args)
@@ -692,6 +721,18 @@ auto Graph::Lane::exit() -> Node&
 auto Graph::Lane::exit() const -> const Node&
 {
   return _pimpl->exit;
+}
+
+//==============================================================================
+auto Graph::Lane::properties() -> Properties&
+{
+  return _pimpl->properties;
+}
+
+//==============================================================================
+auto Graph::Lane::properties() const -> const Properties&
+{
+  return _pimpl->properties;
 }
 
 //==============================================================================
@@ -820,7 +861,8 @@ std::size_t Graph::num_waypoints() const
 //==============================================================================
 auto Graph::add_lane(
   const Lane::Node& entry,
-  const Lane::Node& exit) -> Lane&
+  const Lane::Node& exit,
+  Lane::Properties properties) -> Lane&
 {
   assert(entry.waypoint_index() < _pimpl->waypoints.size());
   assert(exit.waypoint_index() < _pimpl->waypoints.size());
@@ -836,7 +878,7 @@ auto Graph::add_lane(
       _pimpl->lanes.size(),
       std::move(entry),
       std::move(exit),
-      false, std::size_t()));
+      std::move(properties)));
 
   return _pimpl->lanes.back();
 }


### PR DESCRIPTION
This PR introduces the ability to (optionally) set speed limits on nav graph lanes. These speed limits will be respected by the planner.

For the initial implementation if there are multiple speed limits along one continuous stretch (collinear lanes that have different speed limits), then the planner will use the lowest speed limit along the entire stretch (or possibly come to a stop at the point where the lanes change and then switch speeds, if that would be faster). This approach does not provide optimal trajectories. We should instead have the robot accelerate/decelerate at each lane intersection in compliance with the changes in speed limits, but that will take considerably more effort to work out, so we'll start with this and improve the implementation in a future PR.