### PR TITLE
Use std::atomic_bool for safe synchronization

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -28,6 +28,8 @@
 
 #include <rmf_utils/optional.hpp>
 
+#include <atomic>
+
 namespace rmf_traffic {
 namespace agv {
 
@@ -150,7 +152,7 @@ public:
     Options(
       rmf_utils::clone_ptr<RouteValidator> validator,
       Duration min_hold_time = DefaultMinHoldingTime,
-      std::shared_ptr<const bool> interrupt_flag = nullptr,
+      std::shared_ptr<const std::atomic_bool> interrupt_flag = nullptr,
       rmf_utils::optional<double> maximum_cost_estimate = rmf_utils::nullopt,
       rmf_utils::optional<std::size_t> saturation_limit = rmf_utils::nullopt);
 
@@ -216,11 +218,11 @@ public:
     ///
     /// \warning Using this function will replace anything that was given to
     /// interrupter.
-    Options& interrupt_flag(std::shared_ptr<const bool> flag);
+    Options& interrupt_flag(std::shared_ptr<const std::atomic_bool> flag);
 
     /// Get the interrupt flag that will stop this planner if it has run for too
     /// long.
-    const std::shared_ptr<const bool>& interrupt_flag() const;
+    const std::shared_ptr<const std::atomic_bool>& interrupt_flag() const;
 
     /// Set the maximum cost estimate that the planner should allow. If the cost
     /// estimate of the best possible plan that the planner could produce ever
@@ -628,7 +630,7 @@ public:
   ///   A new interrupt flag to listen to while planning.
   ///
   /// \return true if a plan has been found, false otherwise.
-  bool resume(std::shared_ptr<const bool> interrupt_flag);
+  bool resume(std::shared_ptr<const std::atomic_bool> interrupt_flag);
 
   /// Get a mutable reference to the options that will be used by this planning
   /// task.

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -237,7 +237,8 @@ auto Planner::Options::interrupt_flag(
   if (flag)
   {
     _pimpl->interrupt_flag = flag;
-    _pimpl->interrupter = [flag = std::move(flag)]() -> bool { return *flag; };
+    _pimpl->interrupter = [flag = std::move(flag)]() -> bool
+      { return flag->load(std::memory_order::memory_order_relaxed); };
   }
   else
   {

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -147,7 +147,7 @@ public:
   rmf_utils::optional<std::size_t> saturation_limit;
 
   std::function<bool()> interrupter = nullptr;
-  std::shared_ptr<const bool> interrupt_flag = nullptr;
+  std::shared_ptr<const std::atomic_bool> interrupt_flag = nullptr;
 
 };
 
@@ -155,7 +155,7 @@ public:
 Planner::Options::Options(
   rmf_utils::clone_ptr<RouteValidator> validator,
   const Duration min_hold_time,
-  std::shared_ptr<const bool> interrupt_flag,
+  std::shared_ptr<const std::atomic_bool> interrupt_flag,
   rmf_utils::optional<double> maximum_cost_estimate,
   rmf_utils::optional<std::size_t> saturation_limit)
 : _pimpl(rmf_utils::make_impl<Implementation>(
@@ -232,7 +232,7 @@ const std::function<bool()>& Planner::Options::interrupter() const
 
 //==============================================================================
 auto Planner::Options::interrupt_flag(
-  std::shared_ptr<const bool> flag) -> Options&
+  std::shared_ptr<const std::atomic_bool> flag) -> Options&
 {
   if (flag)
   {
@@ -249,7 +249,8 @@ auto Planner::Options::interrupt_flag(
 }
 
 //==============================================================================
-const std::shared_ptr<const bool>& Planner::Options::interrupt_flag() const
+const std::shared_ptr<const std::atomic_bool>&
+Planner::Options::interrupt_flag() const
 {
   return _pimpl->interrupt_flag;
 }
@@ -844,7 +845,8 @@ bool Planner::Result::resume()
 }
 
 //==============================================================================
-bool Planner::Result::resume(std::shared_ptr<const bool> interrupt_flag)
+bool Planner::Result::resume(
+  std::shared_ptr<const std::atomic_bool> interrupt_flag)
 {
   _pimpl->state.conditions.options.interrupt_flag(std::move(interrupt_flag));
   return resume();

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -410,9 +410,8 @@ inline void CHECK_PLAN(
   }
 }
 
-__attribute__((no_sanitize("thread")))
 void set_interrupt_flag(
-  const std::shared_ptr<bool>& interrupt_flag, bool value)
+  const std::shared_ptr<std::atomic_bool>& interrupt_flag, bool value)
 {
   *interrupt_flag = value;
 }
@@ -494,7 +493,7 @@ SCENARIO("Test Options", "[options]")
   using Planner = rmf_traffic::agv::Planner;
   using Duration = std::chrono::nanoseconds;
 
-  auto interrupt_flag = std::make_shared<bool>(false);
+  auto interrupt_flag = std::make_shared<std::atomic_bool>(false);
   Duration hold_time = std::chrono::seconds(6);
 
   Planner::Options default_options(nullptr, hold_time, interrupt_flag);
@@ -623,7 +622,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         auto options = rmf_traffic::agv::Planner::Options{
           nullptr,
           rmf_traffic::agv::Planner::Options::DefaultMinHoldingTime,
-          std::shared_ptr<bool>(nullptr),
+          std::shared_ptr<std::atomic_bool>(nullptr),
           0 // Maximum cost estimate must be 0
         };
         rmf_traffic::agv::Planner planner{
@@ -1416,7 +1415,7 @@ SCENARIO("DP1 Graph")
   };
 
   const rmf_traffic::Time time = std::chrono::steady_clock::now();
-  const auto interrupt_flag = std::make_shared<bool>(false);
+  const auto interrupt_flag = std::make_shared<std::atomic_bool>(false);
   const rmf_traffic::agv::Planner::Options default_options{
     make_test_schedule_validator(database, profile),
     std::chrono::seconds(5),
@@ -1924,7 +1923,9 @@ SCENARIO("DP1 Graph")
 
       THEN("Plan can resume and find a solution")
       {
-        const auto new_interrupt_flag = std::make_shared<bool>(false);
+        const auto new_interrupt_flag =
+          std::make_shared<std::atomic_bool>(false);
+
         result->resume(new_interrupt_flag);
         CHECK(*result);
       }
@@ -2234,7 +2235,7 @@ SCENARIO("Test planner with various start conditions")
   rmf_traffic::schedule::ItineraryVersion iv_o = 0;
   rmf_traffic::RouteId ri_o = 0;
 
-  const auto interrupt_flag = std::make_shared<bool>(false);
+  const auto interrupt_flag = std::make_shared<std::atomic_bool>(false);
   Duration hold_time = std::chrono::seconds(6);
   const rmf_traffic::agv::Planner::Options default_options{
     make_test_schedule_validator(database, profile),
@@ -2588,7 +2589,7 @@ SCENARIO("Test starts using graph with non-colinear waypoints")
     create_test_profile(UnitCircle)};
 
   rmf_traffic::schedule::Database database;
-  const auto interrupt_flag = std::make_shared<bool>(false);
+  const auto interrupt_flag = std::make_shared<std::atomic_bool>(false);
   Duration hold_time = std::chrono::seconds(1);
   const rmf_traffic::agv::Planner::Options default_options{
     make_test_schedule_validator(database, traits.profile()),
@@ -2708,7 +2709,7 @@ SCENARIO("Multilevel Planning")
     create_test_profile(UnitCircle)};
 
   rmf_traffic::schedule::Database database;
-  const auto interrupt_flag = std::make_shared<bool>(false);
+  const auto interrupt_flag = std::make_shared<std::atomic_bool>(false);
   Duration hold_time = std::chrono::seconds(1);
   const rmf_traffic::agv::Planner::Options default_options{
     make_test_schedule_validator(database, traits.profile()),
@@ -2962,7 +2963,7 @@ SCENARIO("Adjacent entry and exit events", "[debug]")
     create_test_profile(UnitCircle)};
 
   rmf_traffic::schedule::Database database;
-  const auto interrupt_flag = std::make_shared<bool>(false);
+  const auto interrupt_flag = std::make_shared<std::atomic_bool>(false);
   Duration hold_time = std::chrono::seconds(1);
   const rmf_traffic::agv::Planner::Options default_options{
     make_test_schedule_validator(database, traits.profile()),

--- a/rmf_traffic/thirdparty/fcl/include/fcl/geometry/shape/sphere-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/geometry/shape/sphere-inl.h
@@ -57,11 +57,17 @@ Sphere<S>::Sphere(S radius) : ShapeBase<S>(), radius(radius)
 template <typename S>
 void Sphere<S>::computeLocalAABB()
 {
+  if (_last_local_aabb_radius == radius)
+    return;
+
+  SpinLock lock(_mutex_compute_local_aabb);
+
   this->aabb_local.max_.setConstant(radius);
   this->aabb_local.min_.setConstant(-radius);
 
   this->aabb_center = this->aabb_local.center();
   this->aabb_radius = radius;
+  _last_local_aabb_radius = radius;
 }
 
 //==============================================================================


### PR DESCRIPTION
As reported in https://github.com/open-rmf/rmf_ros2/issues/82, Thread Sanitizer is complaining about certain data races that are happening on `rmf_traffic` data structures.

So far these data races have not had an observable impact, and are probably harmless, but this PR switches us over to using best practices anyway.