### PR TITLE
Using eigen3_cmake_module to fix RHEL build

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -33,7 +33,8 @@ set(using_new_fcl true)
 set(FCL_LIBRARIES fcl)
 
 find_package(rmf_utils REQUIRED)
-find_package(Eigen3 REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3)
 find_package(Threads)
 
 # ===== Traffic control library
@@ -61,6 +62,8 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
   endif()
 
   target_include_directories(test_rmf_traffic
+    PUBLIC
+      "${Eigen3_INCLUDE_DIRS}"
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )

--- a/rmf_traffic/cmake/rmf_traffic-config.cmake.in
+++ b/rmf_traffic/cmake/rmf_traffic-config.cmake.in
@@ -4,11 +4,24 @@ get_filename_component(rmf_traffic_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 include(CMakeFindDependencyMacro)
 
+find_dependency(eigen3_cmake_module REQUIRED)
 find_dependency(Eigen3 REQUIRED)
 find_dependency(rmf_utils REQUIRED)
 
 if(NOT TARGET rmf_traffic::rmf_traffic)
     include("${rmf_traffic_CMAKE_DIR}/rmf_traffic-targets.cmake")
 endif()
+
+if (NOT eigen3_cmake_module_FOUND)
+  set(rmf_traffic_FOUND 0)
+  return()
+endif()
+
+if (NOT Eigen3_FOUND)
+  set(rmf_traffic_FOUND 0)
+  return()
+endif()
+
+list(APPEND rmf_traffic_INCLUDE_DIRS ${Eigen3_INCLUDE_DIRS})
 
 check_required_components(rmf_traffic)

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -9,7 +9,13 @@
   <license>Apache License 2.0</license>
   <author>Grey</author>
 
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <build_depend>eigen</build_depend>
   <build_depend>rmf_utils</build_depend>
+
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+  <build_export_depend>eigen</build_export_depend>
   <build_export_depend>rmf_utils</build_export_depend>
 
   <depend>libccd-dev</depend>
@@ -22,7 +28,6 @@
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>rmf_cmake_uncrustify</test_depend>
 
-  <depend>eigen</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

It seems that the `Eigen3` `cmake` file provided in RHEL8 does not set the variables correctly and when trying to build the packages that depend on `Eigen3` even though the library is found, include files don't seem to be found during the compilation process:

```
...
/opt/ros/galactic/include/rmf_traffic/Trajectory.hpp:26:10: fatal error: Eigen/Geometry: No such file or directory
#include <Eigen/Geometry>
...
```

### Fixed bug

This seems to be an issue that was already there on `Ubuntu bionic` and that is well documented and fixed by this package: https://github.com/ros2/eigen3_cmake_module

### Fix applied

This PR adds a dependency to `eigen3_cmake_module` and applies the necessary changes to make the package compile correctly in RHEL 8. It has been tested that these changes do not affect current compilation on `Ubuntu` distributions.