### PR TITLE
the CMake user package registry can do unexpected things.

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -147,5 +147,3 @@ export(
   FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-targets.cmake
   NAMESPACE rmf_traffic::
 )
-
-export(PACKAGE rmf_traffic)


### PR DESCRIPTION
The CMake user package registry can cause unexpected behavior if people aren't accustomed to it. This PR removes the `export(PACKAGE ...)` invocation that adds to the user package registry in `~/.cmake/packages` during the `colcon` build/install process.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>