### PR TITLE
Use ament_cmake_uncrustify

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -44,8 +44,8 @@ add_library(rmf_traffic SHARED
 )
 
 find_package(ament_cmake_catch2 QUIET)
-find_package(rmf_cmake_uncrustify QUIET)
-if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
+find_package(ament_cmake_uncrustify QUIET)
+if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
 
   ament_add_catch2(
@@ -72,7 +72,7 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
     NAMES "rmf_code_style.cfg"
     PATHS "${rmf_utils_DIR}/../../../share/rmf_utils/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     ARGN include src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -26,7 +26,7 @@
   <!--<depend>fcl</depend>-->
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
 
   <export>


### PR DESCRIPTION
We currently have the rmf_cmake_uncrustify package that is used for style checking with colcon test. The original reason for having this package and not using ament_cmake_uncrustify was that the latter did not support custom uncrustify configuration files. But this feature was [merged upstream](https://github.com/ament/ament_lint/pull/200) quite a while ago and has been part of `foxy` and `galactic` releases. Hence, switching back to `ament_cmake_uncrustify` for ease of maintenance and distribution.