### PR TITLE
Allow the rectifier to help fix participant ID and description discrepancies

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -4,7 +4,7 @@ project(rmf_traffic VERSION 1.4.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()

--- a/rmf_traffic/include/rmf_traffic/Profile.hpp
+++ b/rmf_traffic/include/rmf_traffic/Profile.hpp
@@ -45,7 +45,7 @@ public:
     geometry::ConstFinalConvexShapePtr vicinity = nullptr);
 
   /// Equality operator
-  bool operator==(const Profile & rhs) const;
+  bool operator==(const Profile& rhs) const;
 
   /// Set the footprint of the participant.
   Profile& footprint(geometry::ConstFinalConvexShapePtr shape);

--- a/rmf_traffic/include/rmf_traffic/Profile.hpp
+++ b/rmf_traffic/include/rmf_traffic/Profile.hpp
@@ -44,6 +44,9 @@ public:
     geometry::ConstFinalConvexShapePtr footprint,
     geometry::ConstFinalConvexShapePtr vicinity = nullptr);
 
+  /// Equality operator
+  bool operator==(const Profile & rhs) const;
+
   /// Set the footprint of the participant.
   Profile& footprint(geometry::ConstFinalConvexShapePtr shape);
 

--- a/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
@@ -76,9 +76,9 @@ public:
     Profile profile);
 
   /// Equality operator
-  bool operator==(const ParticipantDescription & rhs) const;
+  bool operator==(const ParticipantDescription& rhs) const;
   /// Inequality operator
-  bool operator!=(const ParticipantDescription & rhs) const;
+  bool operator!=(const ParticipantDescription& rhs) const;
 
   /// Set the name of the participant.
   ParticipantDescription& name(std::string value);

--- a/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
@@ -75,6 +75,11 @@ public:
     Rx responsiveness,
     Profile profile);
 
+  /// Equality operator
+  bool operator==(const ParticipantDescription & rhs) const;
+  /// Inequality operator
+  bool operator!=(const ParticipantDescription & rhs) const;
+
   /// Set the name of the participant.
   ParticipantDescription& name(std::string value);
 

--- a/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
@@ -69,17 +69,17 @@ public:
     const std::vector<Range>& ranges,
     ItineraryVersion last_known_version);
 
-  /// Get the current ItineraryVersion of the Participant.
-  ItineraryVersion current_version() const;
-
-  /// Get the ID of the Participant
-  ParticipantId get_id() const;
-
   /// Correct the ID of the participant
   void correct_id(ParticipantId new_id);
 
+  /// Get the current ItineraryVersion of the Participant.
+  std::optional<ItineraryVersion> current_version() const;
+
+  /// Get the ID of the Participant
+  std::optional<ParticipantId> get_id() const;
+
   /// Get the description of the Participant
-  const ParticipantDescription& get_description() const;
+  std::optional<ParticipantDescription> get_description() const;
 
   class Implementation;
 private:

--- a/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
@@ -72,6 +72,15 @@ public:
   /// Get the current ItineraryVersion of the Participant.
   ItineraryVersion current_version() const;
 
+  /// Get the ID of the Participant
+  ParticipantId get_id() const;
+
+  /// Correct the ID of the participant
+  void correct_id(ParticipantId new_id);
+
+  /// Get the description of the Participant
+  const ParticipantDescription& get_description() const;
+
   class Implementation;
 private:
   Rectifier();

--- a/rmf_traffic/src/rmf_traffic/Profile.cpp
+++ b/rmf_traffic/src/rmf_traffic/Profile.cpp
@@ -33,7 +33,7 @@ Profile::Profile(
 }
 
 //==============================================================================
-bool Profile::operator==(const Profile & rhs) const
+bool Profile::operator==(const Profile& rhs) const
 {
   // TODO(geoff): Something in here segfaults
   if (!_pimpl && !rhs._pimpl)

--- a/rmf_traffic/src/rmf_traffic/Profile.cpp
+++ b/rmf_traffic/src/rmf_traffic/Profile.cpp
@@ -35,7 +35,7 @@ Profile::Profile(
 //==============================================================================
 bool Profile::operator==(const Profile& rhs) const
 {
-  // TODO(geoff): Something in here segfaults
+  // TODO(MXG): We should write tests for the shape and profile comparisons.
   if (!_pimpl && !rhs._pimpl)
   {
     return true;
@@ -45,41 +45,38 @@ bool Profile::operator==(const Profile& rhs) const
     return false;
   }
 
-  bool r1 = false;
-  if (_pimpl->footprint && rhs._pimpl->footprint)
+  const auto& self_footprint = footprint();
+  const auto& other_footprint = rhs.footprint();
+  if (self_footprint && other_footprint)
   {
     // Both pointers are valid so check what they point to for equality
-    r1 = *_pimpl->footprint == *rhs._pimpl->footprint;
+    if (*self_footprint != *other_footprint)
+      return false;
   }
-  else if (_pimpl->footprint || rhs._pimpl->footprint)
+  else if (self_footprint || other_footprint)
   {
     // Only one pointer is valid, so they can't be equal
-    r1 = false;
-  }
-  else
-  {
-    // Both pointers are invalid, so equal
-    r1 = true;
+    return false;
   }
 
-  bool r2 = false;
-  if (_pimpl->vicinity && rhs._pimpl->vicinity)
+  // Using the getter functions for vicinity is important because the Profile
+  // class has a behavior where it will return the footprint as the vicinity
+  // if a vicinity was never specified.
+  const auto& self_vicinity = vicinity();
+  const auto& other_vicinity = rhs.vicinity();
+  if (self_vicinity && other_vicinity)
   {
     // Both pointers are valid so check what they point to for equality
-    r2 = *_pimpl->footprint == *rhs._pimpl->footprint;
+    if (*self_vicinity != *other_vicinity)
+      return false;
   }
   else if (_pimpl->vicinity || rhs._pimpl->vicinity)
   {
     // Only one pointer is valid, so they can't be equal
-    r2 = false;
-  }
-  else
-  {
-    // Both pointers are invalid, so equal
-    r2 = true;
+    return false;
   }
 
-  return r1 && r2;
+  return true;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/Profile.cpp
+++ b/rmf_traffic/src/rmf_traffic/Profile.cpp
@@ -33,6 +33,56 @@ Profile::Profile(
 }
 
 //==============================================================================
+bool Profile::operator==(const Profile & rhs) const
+{
+  // TODO(geoff): Something in here segfaults
+  if (!_pimpl && !rhs._pimpl)
+  {
+    return true;
+  }
+  else if (!_pimpl || !rhs._pimpl)
+  {
+    return false;
+  }
+
+  bool r1 = false;
+  if (_pimpl->footprint && rhs._pimpl->footprint)
+  {
+    // Both pointers are valid so check what they point to for equality
+    r1 = *_pimpl->footprint == *rhs._pimpl->footprint;
+  }
+  else if (_pimpl->footprint || rhs._pimpl->footprint)
+  {
+    // Only one pointer is valid, so they can't be equal
+    r1 = false;
+  }
+  else
+  {
+    // Both pointers are invalid, so equal
+    r1 = true;
+  }
+
+  bool r2 = false;
+  if (_pimpl->vicinity && rhs._pimpl->vicinity)
+  {
+    // Both pointers are valid so check what they point to for equality
+    r2 = *_pimpl->footprint == *rhs._pimpl->footprint;
+  }
+  else if (_pimpl->vicinity || rhs._pimpl->vicinity)
+  {
+    // Only one pointer is valid, so they can't be equal
+    r2 = false;
+  }
+  else
+  {
+    // Both pointers are invalid, so equal
+    r2 = true;
+  }
+
+  return r1 && r2;
+}
+
+//==============================================================================
 Profile& Profile::footprint(geometry::ConstFinalConvexShapePtr shape)
 {
   _pimpl->footprint = std::move(shape);

--- a/rmf_traffic/src/rmf_traffic/geometry/ShapeInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/ShapeInternal.hpp
@@ -119,7 +119,10 @@ template<typename T>
 std::function<bool(const Shape& other)> make_equality_comparator(
   const T& myself)
 {
-  return [&myself](const Shape& other)
+  // TODO(MXG): This is making an unnecessary copy of the original shape. This
+  // is okay when all we're dealing with is circles, but this would become very
+  // inefficient for larger objects with many parameters/vertices.
+  return [myself](const Shape& other)
     {
       if (const auto* other_derived = dynamic_cast<const T*>(&other))
       {

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -126,6 +126,25 @@ ItineraryVersion Participant::Implementation::Shared::current_version() const
 }
 
 //==============================================================================
+ParticipantId Participant::Implementation::Shared::get_id() const
+{
+  return _id;
+}
+
+//==============================================================================
+void Participant::Implementation::Shared::correct_id(ParticipantId new_id)
+{
+  _id = new_id;
+}
+
+//==============================================================================
+const ParticipantDescription&
+Participant::Implementation::Shared::get_description() const
+{
+  return _description;
+}
+
+//==============================================================================
 Participant::Implementation::Implementation(
   const Writer::Registration& registration,
   ParticipantDescription description,

--- a/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
@@ -50,6 +50,22 @@ ParticipantDescription::ParticipantDescription(
 }
 
 //==============================================================================
+bool ParticipantDescription::operator==(const ParticipantDescription & rhs) const
+{
+  return _pimpl->name == rhs._pimpl->name &&
+    _pimpl->owner == rhs._pimpl->owner &&
+    _pimpl->responsiveness == rhs._pimpl->responsiveness;
+    // TODO(geoff): Why does adding this make it segfault?
+    //_pimpl->profile == rhs._pimpl->profile;
+}
+
+//==============================================================================
+bool ParticipantDescription::operator!=(const ParticipantDescription & rhs) const
+{
+  return !(*this == rhs);
+}
+
+//==============================================================================
 ParticipantDescription& ParticipantDescription::name(std::string value)
 {
   _pimpl->name = std::move(value);

--- a/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
@@ -52,11 +52,10 @@ ParticipantDescription::ParticipantDescription(
 //==============================================================================
 bool ParticipantDescription::operator==(const ParticipantDescription& rhs) const
 {
-  // TODO(MXG): Create a comparison function for profiles
-  // _pimpl->profile == rhs._pimpl->profile;
   return _pimpl->name == rhs._pimpl->name &&
     _pimpl->owner == rhs._pimpl->owner &&
-    _pimpl->responsiveness == rhs._pimpl->responsiveness;
+    _pimpl->responsiveness == rhs._pimpl->responsiveness &&
+    _pimpl->profile == rhs._pimpl->profile;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
@@ -50,17 +50,17 @@ ParticipantDescription::ParticipantDescription(
 }
 
 //==============================================================================
-bool ParticipantDescription::operator==(const ParticipantDescription & rhs) const
+bool ParticipantDescription::operator==(const ParticipantDescription& rhs) const
 {
+  // TODO(MXG): Create a comparison function for profiles
+  // _pimpl->profile == rhs._pimpl->profile;
   return _pimpl->name == rhs._pimpl->name &&
     _pimpl->owner == rhs._pimpl->owner &&
     _pimpl->responsiveness == rhs._pimpl->responsiveness;
-    // TODO(geoff): Why does adding this make it segfault?
-    //_pimpl->profile == rhs._pimpl->profile;
 }
 
 //==============================================================================
-bool ParticipantDescription::operator!=(const ParticipantDescription & rhs) const
+bool ParticipantDescription::operator!=(const ParticipantDescription& rhs) const
 {
   return !(*this == rhs);
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -43,15 +43,6 @@ void Rectifier::retransmit(
 }
 
 //==============================================================================
-ParticipantId Rectifier::get_id() const
-{
-  // TODO(geoff): There should be a check here for if it couldn't be locked.
-  // What is the correct action in that situation?
-  const auto shared = _pimpl->participant.lock();
-  return shared->get_id();
-}
-
-//==============================================================================
 void Rectifier::correct_id(ParticipantId new_id)
 {
   if (const auto shared = _pimpl->participant.lock())
@@ -59,12 +50,35 @@ void Rectifier::correct_id(ParticipantId new_id)
 }
 
 //==============================================================================
-const ParticipantDescription& Rectifier::get_description() const
+std::optional<ItineraryVersion> Rectifier::current_version() const
+{
+  if (const auto shared = _pimpl->participant.lock())
+    return shared->current_version();
+
+  return std::nullopt;
+}
+
+//==============================================================================
+std::optional<ParticipantId> Rectifier::get_id() const
 {
   // TODO(geoff): There should be a check here for if it couldn't be locked.
   // What is the correct action in that situation?
-  const auto shared = _pimpl->participant.lock();
-  return shared->get_description();
+  if (const auto shared = _pimpl->participant.lock())
+    return shared->get_id();
+
+  return std::nullopt;
+}
+
+//==============================================================================
+std::optional<rmf_traffic::schedule::ParticipantDescription>
+Rectifier::get_description() const
+{
+  // TODO(geoff): There should be a check here for if it couldn't be locked.
+  // What is the correct action in that situation?
+  if (const auto shared = _pimpl->participant.lock())
+    return shared->get_description();
+
+  return std::nullopt;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -43,6 +43,31 @@ void Rectifier::retransmit(
 }
 
 //==============================================================================
+ParticipantId Rectifier::get_id() const
+{
+  // TODO(geoff): There should be a check here for if it couldn't be locked.
+  // What is the correct action in that situation?
+  const auto shared = _pimpl->participant.lock();
+  return shared->get_id();
+}
+
+//==============================================================================
+void Rectifier::correct_id(ParticipantId new_id)
+{
+  if (const auto shared = _pimpl->participant.lock())
+    shared->correct_id(new_id);
+}
+
+//==============================================================================
+const ParticipantDescription& Rectifier::get_description() const
+{
+  // TODO(geoff): There should be a check here for if it couldn't be locked.
+  // What is the correct action in that situation?
+  const auto shared = _pimpl->participant.lock();
+  return shared->get_description();
+}
+
+//==============================================================================
 Rectifier::Rectifier()
 {
   // Do nothing

--- a/rmf_traffic/src/rmf_traffic/schedule/internal_Participant.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/internal_Participant.hpp
@@ -21,6 +21,7 @@
 #include <rmf_traffic/schedule/Participant.hpp>
 
 #include <rmf_utils/Modular.hpp>
+#include <rmf_utils/RateLimiter.hpp>
 
 #include <map>
 
@@ -37,7 +38,7 @@ public:
     std::shared_ptr<Writer> writer,
     std::shared_ptr<RectificationRequesterFactory> rectifier_factory);
 
-  class Shared
+  class Shared : public std::enable_shared_from_this<Shared>
   {
   public:
 
@@ -45,6 +46,10 @@ public:
       const Writer::Registration& registration,
       ParticipantDescription description,
       std::shared_ptr<Writer> writer);
+
+    RouteId set(std::vector<Route> itinerary);
+
+    void clear();
 
     void retransmit(
       const std::vector<Rectifier::Range>& from,
@@ -80,6 +85,8 @@ public:
 
     ChangeHistory _change_history;
     rmf_traffic::Duration _cumulative_delay = std::chrono::seconds(0);
+
+    rmf_utils::RateLimiter _version_mismatch_limiter;
   };
 
   // Note: It would be better if this constructor were private, but we need to

--- a/rmf_traffic/src/rmf_traffic/schedule/internal_Participant.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/internal_Participant.hpp
@@ -52,6 +52,12 @@ public:
 
     ItineraryVersion current_version() const;
 
+    ParticipantId get_id() const;
+
+    void correct_id(ParticipantId new_id);
+
+    const ParticipantDescription& get_description() const;
+
     ~Shared();
 
   private:
@@ -60,7 +66,7 @@ public:
     Writer::Input make_input(std::vector<Route> itinerary);
     ItineraryVersion get_next_version();
 
-    const ParticipantId _id;
+    ParticipantId _id;
     ItineraryVersion _version;
     RouteId _last_route_id;
     const ParticipantDescription _description;


### PR DESCRIPTION
These add some features to the schedule participant rectifier that will allow remote writers to fix discrepancies between their local participants and the remote database's model of them.

This depends on https://github.com/open-rmf/rmf_utils/pull/18 which should be merged first.