### PR TITLE
Using placeholders to add dependency only if the package is found

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -33,9 +33,13 @@ set(using_new_fcl true)
 set(FCL_LIBRARIES fcl)
 
 find_package(rmf_utils REQUIRED)
-find_package(eigen3_cmake_module QUIET)
 find_package(Eigen3 REQUIRED)
 find_package(Threads)
+
+find_package(eigen3_cmake_module QUIET)
+if (eigen3_cmake_module_FOUND)
+  set(RMF_TRAFFIC_DEPENDS_EIGEN3_CMAKE_MODULE "find_dependency(eigen3_cmake_module)")
+endif()
 
 # ===== Traffic control library
 file(GLOB_RECURSE core_lib_srcs "src/rmf_traffic/*.cpp")

--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -33,13 +33,13 @@ set(using_new_fcl true)
 set(FCL_LIBRARIES fcl)
 
 find_package(rmf_utils REQUIRED)
-find_package(Eigen3 REQUIRED)
 find_package(Threads)
 
 find_package(eigen3_cmake_module QUIET)
 if (eigen3_cmake_module_FOUND)
   set(RMF_TRAFFIC_DEPENDS_EIGEN3_CMAKE_MODULE "find_dependency(eigen3_cmake_module)")
 endif()
+find_package(Eigen3 REQUIRED)
 
 # ===== Traffic control library
 file(GLOB_RECURSE core_lib_srcs "src/rmf_traffic/*.cpp")

--- a/rmf_traffic/cmake/rmf_traffic-config.cmake.in
+++ b/rmf_traffic/cmake/rmf_traffic-config.cmake.in
@@ -4,7 +4,7 @@ get_filename_component(rmf_traffic_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(eigen3_cmake_module)
+@RMF_TRAFFIC_DEPENDS_EIGEN3_CMAKE_MODULE@
 find_dependency(Eigen3)
 find_dependency(rmf_utils)
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Fixes https://github.com/open-rmf/rmf_traffic/issues/55.

Edit: Apologies for the branch name pattern :man_facepalming: 

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

Using placeholders in `rmf_traffic/cmake/rmf_traffic-config.cmake.in`, to be generated for `eigen3_cmake_module` only if it is found.