### PR TITLE
Provide a utility for generating waypoint names

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
@@ -97,6 +97,27 @@ public:
     /// The name of a waypoint can only be set using add_key() or set_key().
     const std::string* name() const;
 
+    /// If this waypoint has a name, the name will be returned. Otherwise it
+    /// will return the waypoint index, formatted into a string based on
+    /// the index_format argument.
+    ///
+    /// \param[in] name_format
+    ///   If this waypoint has an assigned name, the first instance of "%s"
+    ///   within name_format will be replaced with the name of the waypoint. If
+    ///   there is no %s in the name_format string, then this function will
+    ///   simply return the name_format string as-is when the waypoint has a
+    ///   name.
+    ///
+    /// \param[in] index_format
+    ///   If this waypoint does not have an assigned name, the first instance of
+    ///   "%d" within the index_format string will be replaced with the
+    ///   stringified decimal index value of the waypoint. If there is no "%d"
+    ///   in the index_format string, then this function will simply return the
+    ///   index_format string as-is when the waypoint does not have a name.
+    std::string name_or_index(
+      const std::string& name_format = "%s",
+      const std::string& index_format = "#%d") const;
+
     class Implementation;
   private:
     Waypoint();

--- a/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
@@ -156,6 +156,31 @@ const std::string* Graph::Waypoint::name() const
 }
 
 //==============================================================================
+std::string Graph::Waypoint::name_or_index(
+  const std::string& name_format,
+  const std::string& index_format) const
+{
+  if (_pimpl->name)
+  {
+    const auto it = name_format.find_first_of("%s");
+    if (it == std::string::npos)
+      return name_format;
+
+    return name_format.substr(0, it)
+      + _pimpl->name.value()
+      + name_format.substr(it+2);
+  }
+
+  const auto it = index_format.find_first_of("%d");
+  if (it == std::string::npos)
+    return index_format;
+
+  return index_format.substr(0, it)
+    + std::to_string(_pimpl->index)
+    + index_format.substr(it+2);
+}
+
+//==============================================================================
 Graph::Waypoint::Waypoint()
 {
   // Do nothing


### PR DESCRIPTION
We often need to print out (or stringify) the names of waypoints, including waypoints that do not have a designated name. Every place where we need to do this, we have to write custom logic for deciding whether to print the name of the waypoint or whether to stringify its graph index with some extra formatting.

This PR provides a utility to make this process simpler and avoid rewriting this same logic over and over in each place that it's needed.