### PR TITLE
Fixing bugs in FCL conservative advancement implementation

### DIFF
--- a/rmf_traffic/test/unit/test_Conflict.cpp
+++ b/rmf_traffic/test/unit/test_Conflict.cpp
@@ -531,7 +531,7 @@ SCENARIO("DetectConflict unit tests")
   }
 }
 
-SCENARIO("Conservative Advancement Regression Tests", "[conservative_advancement]")
+SCENARIO("Conservative Advancement Regression Tests")
 {
   const rmf_traffic::Profile profile{
     rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(0.1)
@@ -551,7 +551,8 @@ SCENARIO("Conservative Advancement Regression Tests", "[conservative_advancement
       t2.insert(start, {1, 0, 0}, {0, 0, 0});
       t2.insert(finish, {0.5, 0, 0}, {-1, 0, 0});
 
-      CHECK(rmf_traffic::DetectConflict::between(profile, t1, profile, t2).has_value());
+      CHECK(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2).has_value());
     }
   }
 }

--- a/rmf_traffic/test/unit/test_Conflict.cpp
+++ b/rmf_traffic/test/unit/test_Conflict.cpp
@@ -20,7 +20,6 @@
 #include "src/rmf_traffic/DetectConflictInternal.hpp"
 
 #include <rmf_utils/catch.hpp>
-#include <iostream>
 
 using namespace std::chrono_literals;
 
@@ -532,7 +531,7 @@ SCENARIO("DetectConflict unit tests")
   }
 }
 
-SCENARIO("Conservative Advancement Regression Tests")
+SCENARIO("Conservative Advancement Regression Tests", "[conservative_advancement]")
 {
   const rmf_traffic::Profile profile{
     rmf_traffic::geometry::make_final_convex<rmf_traffic::geometry::Circle>(0.1)
@@ -540,17 +539,20 @@ SCENARIO("Conservative Advancement Regression Tests")
 
   GIVEN("Trajectories with final velocities")
   {
-    const auto start = rmf_traffic::Time(rmf_traffic::Duration(0));
-    const auto finish = rmf_traffic::Time(rmf_traffic::time::from_seconds(5.0));
-    rmf_traffic::Trajectory t1;
-    t1.insert(start, {0, 0, 0}, {0, 0, 0});
-    t1.insert(finish, {1, 0, 0}, {1, 0, 0});
+    for (double T = 1.0; T <= 10.0; T += 0.1)
+    {
+      const auto start = rmf_traffic::Time(rmf_traffic::Duration(0));
+      const auto finish = rmf_traffic::Time(rmf_traffic::time::from_seconds(T));
+      rmf_traffic::Trajectory t1;
+      t1.insert(start, {0, 0, 0}, {0, 0, 0});
+      t1.insert(finish, {1, 0, 0}, {1, 0, 0});
 
-    rmf_traffic::Trajectory t2;
-    t2.insert(start, {1, 0, 0}, {0, 0, 0});
-    t2.insert(finish, {0.5, 0, 0}, {-1, 0, 0});
+      rmf_traffic::Trajectory t2;
+      t2.insert(start, {1, 0, 0}, {0, 0, 0});
+      t2.insert(finish, {0.5, 0, 0}, {-1, 0, 0});
 
-    CHECK(rmf_traffic::DetectConflict::between(profile, t1, profile, t2).has_value());
+      CHECK(rmf_traffic::DetectConflict::between(profile, t1, profile, t2).has_value());
+    }
   }
 }
 

--- a/rmf_traffic/thirdparty/fcl/include/fcl/math/motion/spline_motion-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/math/motion/spline_motion-inl.h
@@ -285,7 +285,8 @@ S SplineMotion<S>::computeTBound(const Vector3<S>& n) const
     }
   }
 
-  S T_bound = Ta * T_potential[0] * T_potential[0] * T_potential[0] + Tb * T_potential[0] * T_potential[0] + Tc * T_potential[0];
+  S T_curr = Ta * T_potential[0] * T_potential[0] * T_potential[0] + Tb * T_potential[0] * T_potential[0] + Tc * T_potential[0];
+  S T_bound = T_curr;
   for(unsigned int i = 1; i < T_potential.size(); ++i)
   {
     S T_bound_tmp = Ta * T_potential[i] * T_potential[i] * T_potential[i] + Tb * T_potential[i] * T_potential[i] + Tc * T_potential[i];
@@ -295,6 +296,8 @@ S SplineMotion<S>::computeTBound(const Vector3<S>& n) const
     }
   }
 
+  T_bound -= T_curr;
+  T_bound /= (1.0 - tf_t);
   T_bound /= 6.0;
 
   return T_bound;

--- a/rmf_traffic/thirdparty/fcl/include/fcl/math/motion/spline_motion-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/math/motion/spline_motion-inl.h
@@ -264,7 +264,9 @@ S SplineMotion<S>::computeTBound(const Vector3<S>& n) const
       {
         S tmp = -Tc / (2 * Tb);
         if(tmp < 1 && tmp > tf_t)
+        {
           T_potential.push_back(tmp);
+        }
       }
     }
     else
@@ -273,9 +275,13 @@ S SplineMotion<S>::computeTBound(const Vector3<S>& n) const
       S tmp1 = (-Tb + tmp_delta) / (3 * Ta);
       S tmp2 = (-Tb - tmp_delta) / (3 * Ta);
       if(tmp1 < 1 && tmp1 > tf_t)
+      {
         T_potential.push_back(tmp1);
+      }
       if(tmp2 < 1 && tmp2 > tf_t)
+      {
         T_potential.push_back(tmp2);
+      }
     }
   }
 
@@ -283,13 +289,12 @@ S SplineMotion<S>::computeTBound(const Vector3<S>& n) const
   for(unsigned int i = 1; i < T_potential.size(); ++i)
   {
     S T_bound_tmp = Ta * T_potential[i] * T_potential[i] * T_potential[i] + Tb * T_potential[i] * T_potential[i] + Tc * T_potential[i];
-    if(T_bound_tmp > T_bound) T_bound = T_bound_tmp;
+    if(T_bound_tmp > T_bound)
+    {
+      T_bound = T_bound_tmp;
+    }
   }
 
-
-  S cur_delta = Ta * tf_t * tf_t * tf_t + Tb * tf_t * tf_t + Tc * tf_t;
-
-  T_bound -= cur_delta;
   T_bound /= 6.0;
 
   return T_bound;

--- a/rmf_traffic/thirdparty/fcl/include/fcl/math/motion/tbv_motion_bound_visitor-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/math/motion/tbv_motion_bound_visitor-inl.h
@@ -171,9 +171,6 @@ struct TBVMotionBoundVisitorVisitImpl<S, RSS<S>, SplineMotion<S>>
 
     S R_bound = 2 * (cn_max + cmax + cxn_max + 3 * visitor.bv.r) * ratio;
 
-
-    // std::cout << R_bound << " " << T_bound << std::endl;
-
     return R_bound + T_bound;
   }
 };

--- a/rmf_traffic/thirdparty/fcl/include/fcl/narrowphase/detail/conservative_advancement_func_matrix-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/narrowphase/detail/conservative_advancement_func_matrix-inl.h
@@ -263,7 +263,6 @@ bool conservativeAdvancement(const Shape1& o1,
 
     if(node.delta_t <= node.t_err)
     {
-      // std::cout << node.delta_t << " " << node.t_err << std::endl;
       break;
     }
 

--- a/rmf_traffic/thirdparty/fcl/include/fcl/narrowphase/detail/traversal/distance/shape_conservative_advancement_traversal_node-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/narrowphase/detail/traversal/distance/shape_conservative_advancement_traversal_node-inl.h
@@ -95,7 +95,6 @@ leafTesting(int, int) const
   else
   {
     cur_delta_t = distance / bound;
-    cur_delta_t /= 2.0;
   }
 
   if(cur_delta_t < delta_t)

--- a/rmf_traffic/thirdparty/fcl/include/fcl/narrowphase/detail/traversal/distance/shape_conservative_advancement_traversal_node-inl.h
+++ b/rmf_traffic/thirdparty/fcl/include/fcl/narrowphase/detail/traversal/distance/shape_conservative_advancement_traversal_node-inl.h
@@ -88,8 +88,15 @@ leafTesting(int, int) const
   S bound = bound1 + bound2;
 
   S cur_delta_t;
-  if(bound <= distance) cur_delta_t = 1;
-  else cur_delta_t = distance / bound;
+  if(bound <= distance)
+  {
+    cur_delta_t = 1;
+  }
+  else
+  {
+    cur_delta_t = distance / bound;
+    cur_delta_t /= 2.0;
+  }
 
   if(cur_delta_t < delta_t)
     delta_t  = cur_delta_t;


### PR DESCRIPTION
It seems that the FCL implementation of conservative advancement for two splines has a few bugs in it that allow the conservative advancement algorithm to overshoot. This PR fixes it for the internal version of FCL used by `rmf_traffic`. I'll also be submitting a PR to the upstream FCL to fix it likewise there.