### PR TITLE
Add lanes_into API to AGV Graph

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
@@ -577,6 +577,9 @@ public:
   /// Get the indices of lanes that come out of the given Waypoint index
   const std::vector<std::size_t>& lanes_from(std::size_t wp_index) const;
 
+  /// Get the indices of lanes that arrive into the given Waypoint index
+  const std::vector<std::size_t>& lanes_into(std::size_t wp_index) const;
+
   /// Get a reference to the lane that goes from from_wp to to_wp if such a lane
   /// exists. If no such lane exists, this will return a nullptr. If multiple
   /// exist, this will return the one that was added most recently.

--- a/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
@@ -933,6 +933,12 @@ const std::vector<std::size_t>& Graph::lanes_from(std::size_t wp_index) const
 }
 
 //==============================================================================
+const std::vector<std::size_t>& Graph::lanes_into(std::size_t wp_index) const
+{
+  return _pimpl->lanes_into.at(wp_index);
+}
+
+//==============================================================================
 auto Graph::lane_from(std::size_t from_wp, std::size_t to_wp) -> Lane*
 {
   const auto& lanes = _pimpl->lane_between.at(from_wp);

--- a/rmf_traffic/src/rmf_traffic/agv/internal_Graph.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Graph.hpp
@@ -36,7 +36,6 @@ public:
   std::vector<std::vector<std::size_t>> lanes_from;
 
   // A map from a waypoint index to the set of lanes that can enter into it
-  // TODO(MXG): Consider giving the public Graph API a way to access this
   std::vector<std::vector<std::size_t>> lanes_into;
 
   std::vector<std::unordered_map<std::size_t, std::size_t>> lane_between;

--- a/rmf_traffic/test/unit/agv/test_Graph.cpp
+++ b/rmf_traffic/test/unit/agv/test_Graph.cpp
@@ -110,11 +110,15 @@ SCENARIO("Tests for Graph API")
     CHECK(exit_node.orientation_constraint() != nullptr);
 
     auto& lane1 = graph.add_lane(entry_node, exit_node);
+    CHECK(graph.lanes_from(0).size() == 1);
+    CHECK(graph.lanes_into(0).size() == 0);
     CHECK(graph.num_lanes() == 1);
     CHECK_LANE(lane1, 0, entry_node, exit_node);
     CHECK_LANE(graph.get_lane(0), 0, entry_node, exit_node);
 
     auto& lane2 = graph.add_lane(exit_node, entry_node);
+    CHECK(graph.lanes_from(0).size() == 1);
+    CHECK(graph.lanes_into(0).size() == 1);
     CHECK(graph.num_lanes() == 2);
     CHECK_LANE(lane2, 1, exit_node, entry_node);
     CHECK_LANE(graph.get_lane(1), 1, exit_node, entry_node);


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR adds an API for `lanes_into` to `rmf_traffic`

### Implementation description

Given a `Graph::Waypoint` there is a function to calculate lanes from it but while the data structure to containing lanes into the waypoint was existing, its content was not exposed to a user API.

This PR just adds the user API to return the lanes into a waypoint, as well as adding a few lines of test code to make sure it's behaving sensibly.