### PR TITLE
Always link rmf_traffic against the Threads target

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -97,6 +97,7 @@ endif()
 target_link_libraries(rmf_traffic
   PUBLIC
     rmf_utils::rmf_utils
+    Threads::Threads
   PRIVATE
     ${FCL_LIBRARIES}
 )

--- a/rmf_traffic/cmake/rmf_traffic-config.cmake.in
+++ b/rmf_traffic/cmake/rmf_traffic-config.cmake.in
@@ -7,6 +7,7 @@ include(CMakeFindDependencyMacro)
 @RMF_TRAFFIC_DEPENDS_EIGEN3_CMAKE_MODULE@
 find_dependency(Eigen3)
 find_dependency(rmf_utils)
+find_dependency(Threads)
 
 if(NOT TARGET rmf_traffic::rmf_traffic)
     include("${rmf_traffic_CMAKE_DIR}/rmf_traffic-targets.cmake")


### PR DESCRIPTION
https://github.com/open-rmf/rmf_demos/issues/132 reported that their machine failed to link `rmf_traffic` against pthread. In theory this PR should fix that problem.