### PR TITLE
Using matrix to ease test with different distros

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,19 +9,33 @@ jobs:
   build_and_test:
     name: Build and test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ros_distribution:
+          - galactic
+          - rolling
+        include:
+          # Galactic Geochelone (May 2021 - November 2022)
+          - docker_image: ubuntu:focal
+            ros_distribution: galactic
+            ros_version: 2
+          # Rolling Ridley (No End-Of-Life)
+          - docker_image: ubuntu:jammy
+            ros_distribution: rolling
+            ros_version: 2
     container:
-      image: ubuntu:latest
+      image: ${{ matrix.docker_image }}
     steps:
       - name: pwd
         run: pwd
-      - name: deps
-        uses: ros-tooling/setup-ros@v0.2
+      - name: setup ROS environment
+        uses: ros-tooling/setup-ros@v0.3
         with:
-          required-ros-distributions: rolling
+          required-ros-distributions: ${{ matrix.ros_distribution }}
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: rolling
+          target-ros2-distro: ${{ matrix.ros_distribution }}
           # build all packages listed in the meta package
           package-name: |
             rmf_traffic


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

### Fixed bug

Current github workflow tries to add ROS1 repos on `jammy` and it fails because the Release file it's not there for `jammy`:

`The repository 'http://packages.ros.org/ros/ubuntu jammy Release' does not have a Release file.`

### Fix applied

Moving github workflow to _matrix mode_ as suggested in https://github.com/ros-tooling/setup-ros/tree/v0.3#iterating-on-all-ros-distributions-for-all-platforms to ease the build and test of different combinations of ubuntu distros and ros distros.

Currently building and testing on `focal` + `galactic` and `jammy` + `rolling`.
