### PR TITLE
Make sure the planner will not use a negative- or zero-value speed limit

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.cpp
@@ -195,6 +195,18 @@ void node_to_traversals(
     {
       kin_limits.linear.velocity =
         std::min(kin_limits.linear.velocity, *node.lowest_speed_limit);
+        if (kin_limits.linear.velocity <= 0.0)
+        {
+          const double new_value = kin.limits.linear.velocity * 1e-3;
+          std::cerr << "A speed limit of " << kin_limits.linear.velocity
+                    << " was given for lane " << traversal.finish_lane_index
+                    << ". Speed limits must be strictly greater than 0.0 to "
+                    << "prevent mathematical singularities. The value will be "
+                    << "changed to 0.001*v = " << new_value
+                    << ", but you are advised to fix your usage of rmf_traffic."
+                    << std::endl;
+          kin_limits.linear.velocity = new_value;
+        }
     }
 
     Traversal::Alternative alternative;


### PR DESCRIPTION
~~When a negative or zero value is given for the speed limit on a lane, the planner will now print a warning and override the value with 1/1000 of the agent's normal speed. I expect in most cases setting the speed limit to such a small value is likely to achieve what the user wanted, but it is still strongly recommended to use the lane blocking feature in cases where a "zero speed limit" is really wanted.~~

This PR has been updated so that when a negative- or zero-value speed limit is given for a lane, the lane will be treated as if it is closed, but a warning will be printed out about the unhygienic speed limit value.