### PR TITLE
Change return from nullopt to empty data structure

### DIFF
--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -274,6 +274,7 @@ Version Mirror::latest_version() const
 std::optional<ItineraryView> Mirror::get_itinerary(
   const std::size_t participant_id) const
 {
+  ItineraryView itinerary;
   const auto p = _pimpl->states.find(participant_id);
   if (p == _pimpl->states.end())
   {
@@ -281,13 +282,12 @@ std::optional<ItineraryView> Mirror::get_itinerary(
     // this participant but never received a state. In that case we should
     // return an empty itinerary, not a nullopt.
     if (_pimpl->participant_ids.count(participant_id) > 0)
-      return {};
+      return itinerary;
 
     return std::nullopt;
   }
 
   const auto& state = p->second;
-  ItineraryView itinerary;
   itinerary.reserve(state.storage.size());
   for (const auto& s : state.storage)
     itinerary.push_back(s.second.entry->route);

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -274,7 +274,6 @@ Version Mirror::latest_version() const
 std::optional<ItineraryView> Mirror::get_itinerary(
   const std::size_t participant_id) const
 {
-  ItineraryView itinerary;
   const auto p = _pimpl->states.find(participant_id);
   if (p == _pimpl->states.end())
   {
@@ -282,12 +281,13 @@ std::optional<ItineraryView> Mirror::get_itinerary(
     // this participant but never received a state. In that case we should
     // return an empty itinerary, not a nullopt.
     if (_pimpl->participant_ids.count(participant_id) > 0)
-      return itinerary;
+      return ItineraryView{};
 
     return std::nullopt;
   }
 
   const auto& state = p->second;
+  ItineraryView itinerary;
   itinerary.reserve(state.storage.size());
   for (const auto& s : state.storage)
     itinerary.push_back(s.second.entry->route);


### PR DESCRIPTION
## Bug fix

### Fixed bug

Change function returning nullopt to explicitly return empty data structure, when needed.

### Fix applied

The get_itinerary function, returning an `std::optional`, was using empty value initialization to return an optional with a value that contains an empty data structure.
It seems this behavior was actually a compiler bug and the actual intended behavior is for `return std::nullopt;` and `return {}` to be equivalent, as can be seen in this [stack overflow thread](https://stackoverflow.com/questions/57964217/stdoptional-construct-empty-with-or-stdnullopt).
In [compile explorer](https://godbolt.org/z/mDeDZQ), it shows that with the latest gcc / clang version the two constructors compile to the same assembly, while in gcc 9 / 10 they compile differently and do value initialization.
This PR changes the return to have an explicitly declared empty structure, so we don't rely on undefined compiler behavior (!).