### PR TITLE
Add quickest_path feature to planner

### DIFF
--- a/rmf_traffic/CHANGELOG.md
+++ b/rmf_traffic/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for package rmf_traffic
 
+2.1.0 (XXXX-YY-ZZ)
+------------------
+* Quickest path feature: [#84](https://github.com/open-rmf/rmf_traffic/pull/84)
+
 2.0.0 (2022-03-18)
 ------------------
 * Introduce traffic dependency system: [#70](https://github.com/open-rmf/rmf_traffic/pull/70)

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -549,6 +549,58 @@ public:
     Goal goal,
     Options options) const;
 
+  /// The quickest path is a simplified version of the Planner::Result class
+  /// that can return faster but takes fewer factors into consideration. It
+  /// does not account for translational acceleration/deceleration of the agent,
+  /// nor does it consider rotational velocity or rotational acceleration. The
+  /// traffic schedule is also not accounted for in this option.
+  ///
+  /// QuickestPath will not provide detailed timing information, instead only
+  /// giving a simplified estimate of the cost and the graph indices for the
+  /// quickest path.
+  ///
+  /// This quickest path does consider speed limits on lanes when estimating the
+  /// quickest path. Besides the graph topology, lane closures, event duration
+  /// estimates, and speed limits, no other planner Configuration or Option
+  /// values are considered for the quickest path.
+  ///
+  /// This information is used internally as a heuristic for the full planner.
+  /// The results of using this feature are cached and shared with the full
+  /// planner, and vice-versa.
+  class QuickestPath
+  {
+  public:
+    /// The cost of following this path.
+    double cost() const;
+
+    /// The quickest path that was found.
+    const std::vector<std::size_t>& path() const;
+
+    class Implementation;
+  private:
+    QuickestPath();
+    rmf_utils::impl_ptr<Implementation> _pimpl;
+  };
+
+  /// Calculate the QuickestPath.
+  ///
+  /// \param[in] start
+  ///   One or more start conditions to plan from. This function ignores time
+  ///   and orientation information. Lane information is only used to know the
+  ///   speed limit to use when moving from the start location to the initial
+  ///   waypoint.
+  ///
+  ///   If the start set is left empty, the function will return a nullopt.
+  ///
+  /// \param[in] goal_vertex
+  ///   The goal vertex to plan to.
+  ///
+  /// \return The quickest path from the start to the finish, or a nullopt if
+  /// there is no path that connects the start to the finish.
+  std::optional<QuickestPath> quickest_path(
+      const StartSet& start,
+      std::size_t goal_vertex) const;
+
   class Implementation;
   class Debug;
 private:

--- a/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
@@ -21,6 +21,7 @@
 #include <rmf_traffic/agv/Planner.hpp>
 
 #include "internal_planning.hpp"
+#include "planning/Tree.hpp"
 
 namespace rmf_traffic {
 namespace agv {
@@ -92,6 +93,21 @@ public:
 
   static const Implementation& get(const Result& r);
 
+};
+
+//==============================================================================
+class Planner::QuickestPath::Implementation
+{
+public:
+  planning::ConstForestSolutionPtr solution;
+  double cost_offset;
+
+  static void choose_better(
+    std::optional<Implementation>& left,
+    const Implementation& right);
+
+  static std::optional<QuickestPath> promote(
+    std::optional<Implementation> value);
 };
 
 } // namespace agv

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -99,6 +99,10 @@ public:
     const Planner::Options& options,
     std::optional<std::size_t> max_rollouts) const = 0;
 
+  virtual std::optional<Planner::QuickestPath> quickest_path(
+    const Planner::StartSet& start_vertices,
+    std::size_t goal_vertex) const = 0;
+
   virtual const Planner::Configuration& get_configuration() const = 0;
 
   class Debugger

--- a/rmf_traffic/src/rmf_traffic/agv/planning/CacheManager.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/CacheManager.hpp
@@ -178,6 +178,8 @@ public:
 
   CacheArg get() const;
 
+  const std::shared_ptr<const Generator>& inner() const;
+
 private:
 
   CacheManager(
@@ -293,6 +295,14 @@ template<typename CacheArg>
 CacheArg CacheManager<CacheArg>::get() const
 {
   return CacheArg{_upstream, _storage_initializer};
+}
+
+//==============================================================================
+template<typename CacheArg>
+const std::shared_ptr<const typename CacheArg::Generator>&
+CacheManager<CacheArg>::inner() const
+{
+  return _upstream->generator;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -700,6 +700,13 @@ auto DifferentialDriveHeuristic::generate(
 }
 
 //==============================================================================
+ConstForestSolutionPtr DifferentialDriveHeuristic::inner_heuristic(
+  std::size_t start, std::size_t finish) const
+{
+  return _heuristic->get(start, finish);
+}
+
+//==============================================================================
 CacheManagerPtr<DifferentialDriveHeuristic>
 DifferentialDriveHeuristic::make_manager(
   std::shared_ptr<const Supergraph> supergraph)

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -146,7 +146,7 @@ public:
       const auto initial_lane_index = traversal.initial_lane_index;
       const auto next_lane_index = traversal.finish_lane_index;
       const auto remaining_cost_estimate =
-        _heuristic->get(next_waypoint_index, _goal_waypoint);
+        _heuristic->get_cost(next_waypoint_index, _goal_waypoint);
 
 //      std::cout << "Heuristic " << next_waypoint_index << " -> " << _goal_waypoint << ": ";
 //      if (remaining_cost_estimate.has_value())
@@ -536,7 +536,7 @@ auto DifferentialDriveHeuristic::generate(
   const std::size_t goal_waypoint_index = goal_lane.exit().waypoint_index();
 
   auto start_heuristic =
-    _heuristic->get(start_waypoint_index, goal_waypoint_index);
+    _heuristic->get_cost(start_waypoint_index, goal_waypoint_index);
 
   if (!start_heuristic.has_value())
   {

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
@@ -52,6 +52,9 @@ public:
     const Storage& old_items,
     Storage& new_items) const final;
 
+  ConstForestSolutionPtr inner_heuristic(
+      std::size_t start, std::size_t finish) const;
+
   static CacheManagerPtr<DifferentialDriveHeuristic> make_manager(
     std::shared_ptr<const Supergraph> graph);
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
@@ -47,6 +47,10 @@ public:
     const Planner::Options& options,
     std::optional<std::size_t> max_rollouts) const final;
 
+  std::optional<Planner::QuickestPath> quickest_path(
+    const Planner::StartSet& start_vertices,
+    std::size_t goal_vertex) const final;
+
   const Planner::Configuration& get_configuration() const final;
 
   std::unique_ptr<Debugger> debug_begin(

--- a/rmf_traffic/src/rmf_traffic/agv/planning/MinimalTravelHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/MinimalTravelHeuristic.cpp
@@ -31,7 +31,7 @@ MinimumTravel::ForwardExpander::ForwardExpander(
 {
   _heuristic = [cache, target](WaypointId from)
     {
-      return cache->get(from, target);
+      return cache->get_cost(from, target);
     };
 }
 
@@ -90,7 +90,7 @@ void MinimumTravel::ForwardExpander::retarget(
 {
   _heuristic = [cache, new_target](WaypointId from)
     {
-      return cache->get(from, new_target);
+      return cache->get_cost(from, new_target);
     };
 
   // It is okay to capture by reference because the lambda only gets used within
@@ -118,7 +118,7 @@ MinimumTravel::ReverseExpander::ReverseExpander(
 {
   _heuristic = [cache, target](WaypointId from)
     {
-      return cache->get(target, from);
+      return cache->get_cost(target, from);
     };
 }
 
@@ -177,7 +177,7 @@ void MinimumTravel::ReverseExpander::retarget(
 {
   _heuristic = [cache, new_target](WaypointId from)
     {
-      return cache->get(new_target, from);
+      return cache->get_cost(new_target, from);
     };
 
   // It is okay to capture by reference because the lambda only gets used within

--- a/rmf_traffic/src/rmf_traffic/agv/planning/ShortestPathHeuristic.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/ShortestPathHeuristic.hpp
@@ -189,19 +189,40 @@ public:
 };
 
 //==============================================================================
-inline double combine_costs(
+inline ForestSolution combine_paths(
   const ShortestPath::ForwardNode& a,
   const ShortestPath::ReverseNode& b)
 {
-  return a.current_cost + b.current_cost;
+  const double cost = a.current_cost + b.current_cost;
+  std::vector<std::size_t> path;
+  path.push_back(a.waypoint);
+  auto f_node = a.parent;
+  while (f_node)
+  {
+    path.push_back(f_node->waypoint);
+    f_node = f_node->parent;
+  }
+
+  // Crawling down the forward path gives us a backtrack of the path, so we need
+  // to reverse it here.
+  std::reverse(path.begin(), path.end());
+
+  auto r_node = b.parent;
+  while (r_node)
+  {
+    path.push_back(r_node->waypoint);
+    r_node = r_node->parent;
+  }
+
+  return ForestSolution{cost, std::move(path)};
 }
 
 //==============================================================================
-inline double combine_costs(
+inline ForestSolution combine_paths(
   const ShortestPath::ReverseNode& b,
   const ShortestPath::ForwardNode& a)
 {
-  return combine_costs(a, b);
+  return combine_paths(a, b);
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Tree.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Tree.hpp
@@ -209,6 +209,14 @@ struct DefaultForestSettings
 };
 
 //==============================================================================
+struct ForestSolution
+{
+  double cost;
+  std::vector<std::size_t> path;
+};
+using ConstForestSolutionPtr = std::shared_ptr<const ForestSolution>;
+
+//==============================================================================
 template<typename T>
 class BidirectionalForest
 {
@@ -228,7 +236,9 @@ public:
     std::shared_ptr<const Supergraph> graph,
     Cache cache);
 
-  std::optional<double> get(WaypointId start, WaypointId finish) const;
+  ConstForestSolutionPtr get(WaypointId start, WaypointId finish) const;
+
+  std::optional<double> get_cost(WaypointId start, WaypointId finish) const;
 
   ~BidirectionalForest();
 
@@ -237,10 +247,10 @@ private:
   using ForwardTreeManagerMap = TreeManagerMap<ForwardTree, ReverseTree>;
   using ReverseTreeManagerMap = TreeManagerMap<ReverseTree, ForwardTree>;
 
-  std::optional<std::optional<double>> _check_for_solution(
+  std::optional<ConstForestSolutionPtr> _check_for_solution(
     WaypointId start, WaypointId finish) const;
 
-  std::optional<double> _search(
+  ConstForestSolutionPtr _search(
     WaypointId start,
     std::optional<LockedTree<ForwardTree>> forward_locked,
     WaypointId finish,
@@ -248,6 +258,7 @@ private:
 
   std::shared_ptr<const Supergraph> _graph;
   Cache _heuristic_cache;
+  ConstForestSolutionPtr _identity_solution;
 
   mutable ForwardTreeManagerMap _forward;
   mutable std::atomic_bool _forward_mutex = false;
@@ -255,7 +266,7 @@ private:
   mutable ReverseTreeManagerMap _reverse;
   mutable std::atomic_bool _reverse_mutex = false;
 
-  using GoalCostMap = std::unordered_map<WaypointId, std::optional<double>>;
+  using GoalCostMap = std::unordered_map<WaypointId, ConstForestSolutionPtr>;
   using SolutionMap = std::unordered_map<WaypointId, GoalCostMap>;
   mutable SolutionMap _solutions;
   mutable std::atomic_bool _solutions_mutex = false;

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -824,6 +824,20 @@ SCENARIO("Quickest Path")
     expected_cost = 5 + diagonal_time;
   }
 
+  GIVEN("Same start and goal")
+  {
+    start_set.push_back({time, 0, 0.0});
+    goal_wp = 0;
+    expected_path = {};
+    expected_cost = 0.0;
+  }
+
+  GIVEN("No starts")
+  {
+    // We should get back no solution
+    expected_cost = std::nullopt;
+  }
+
   auto options = rmf_traffic::agv::Planner::Options{nullptr};
   rmf_traffic::agv::Planner planner{
     rmf_traffic::agv::Planner::Configuration{graph, traits},

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -561,6 +561,19 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
 {
   GIVEN("A graph")
   {
+    /*
+     *            ___11-12
+     *      9---10
+     *      |    |
+     *      |    |    8
+     *      |    |    |
+     * 4----5    6    7
+     *      |         |
+     *      |         |
+     * 0----1----2----3
+     *
+     */
+
     const std::string test_map_name = "test_map";
     rmf_traffic::agv::Graph graph;
     graph.add_waypoint(test_map_name, {-5, -5}).set_passthrough_point(true); // 0
@@ -590,11 +603,11 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
     add_bidir_lane(1, 5);
     add_bidir_lane(3, 7);
     add_bidir_lane(4, 5);
+    add_bidir_lane(5, 9);
     add_bidir_lane(6, 10);
     add_bidir_lane(7, 8);
     add_bidir_lane(9, 10);
     add_bidir_lane(10, 11);
-    add_bidir_lane(5, 9);
     add_bidir_lane(11, 12);
 
     const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
@@ -673,6 +686,160 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         CHECK(result);
       }
     }
+  }
+}
+
+SCENARIO("Quickest Path")
+{
+  /*
+   *       11
+   *        |
+   *        v
+   *     8--9--10
+   *   /         \
+   *  3--4--5  6--7
+   *     |     |
+   *     0--1--2
+   *
+   */
+
+  const std::string test_map_name = "test_map";
+  rmf_traffic::agv::Graph graph;
+  graph.add_waypoint(test_map_name, {1.0, 0.0}); // 0
+  graph.add_waypoint(test_map_name, {2.0, 0.0}); // 1
+  graph.add_waypoint(test_map_name, {3.0, 0.0}); // 2
+  graph.add_waypoint(test_map_name, {0.0, 1.0}); // 3
+  graph.add_waypoint(test_map_name, {1.0, 1.0}); // 4
+  graph.add_waypoint(test_map_name, {2.0, 1.0}); // 5
+  graph.add_waypoint(test_map_name, {3.0, 1.0}); // 6
+  graph.add_waypoint(test_map_name, {4.0, 1.0}); // 7
+  graph.add_waypoint(test_map_name, {1.0, 2.0}); // 8
+  graph.add_waypoint(test_map_name, {2.0, 2.0}); // 9
+  graph.add_waypoint(test_map_name, {3.0, 2.0}); // 10
+  graph.add_waypoint(test_map_name, {2.0, 4.0}); // 11
+
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
+
+  add_bidir_lane(0, 1); // 0, 1
+  add_bidir_lane(1, 2); // 2, 3
+  add_bidir_lane(0, 4); // 4, 5
+  add_bidir_lane(2, 6); // 6, 7
+  add_bidir_lane(3, 4); // 8, 9
+  add_bidir_lane(4, 5); // 10, 11
+  add_bidir_lane(6, 7); // 12, 13
+  add_bidir_lane(3, 8); // 14, 15
+  add_bidir_lane(7, 10); // 16, 17
+  add_bidir_lane(8, 9);  // 18, 19
+  add_bidir_lane(9, 10); // 20, 21
+  graph.add_lane(11, 9); // 22
+
+  const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
+  const rmf_traffic::agv::VehicleTraits traits(
+    {1.0, 0.3}, {1.0, 0.45}, profile);
+
+  const double diagonal_time = std::sqrt(2.0);
+  rmf_traffic::agv::Planner::StartSet start_set;
+  std::size_t goal_wp = 0;
+  std::vector<std::size_t> expected_path;
+  std::optional<double> expected_cost;
+  const rmf_traffic::Time time = std::chrono::steady_clock::now();
+
+  GIVEN("Quickest Path Request from 3 -> 7")
+  {
+    start_set.push_back({time, 3, 0.0});
+    goal_wp = 7;
+
+    WHEN("No speed limits")
+    {
+      expected_path = {3, 8, 9, 10, 7};
+      expected_cost = 2.0 + 2.0 * diagonal_time;
+    }
+
+    WHEN("Modest speed limit along 8 -> 10")
+    {
+      const auto speed = 2.0/3.0;
+      graph.get_lane(18).properties().speed_limit(speed);
+      graph.get_lane(20).properties().speed_limit(speed);
+      expected_path = {3, 8, 9, 10, 7};
+      expected_cost = 2.0 / speed + 2.0 * diagonal_time;
+    }
+
+    WHEN("Significant speed limit along 8 -> 10")
+    {
+      const auto speed = 0.5;
+      graph.get_lane(18).properties().speed_limit(speed);
+      graph.get_lane(20).properties().speed_limit(speed);
+
+      // The route will change to following the bottom instead
+      expected_path = {3, 4, 0, 1, 2, 6, 7};
+      expected_cost = 6.0;
+    }
+  }
+
+  GIVEN("Quickest Path Request from multiplpe offset to 9")
+  {
+    const Eigen::Vector2d location = Eigen::Vector2d{2.0, 0.5};
+    start_set.push_back({time, 5, 0.0, location});
+    start_set.push_back({time, 6, 0.0, location, 6});
+    goal_wp = 9;
+
+    WHEN("No speed limits")
+    {
+      expected_path = {6, 7, 10, 9};
+      expected_cost =
+        (location - Eigen::Vector2d{3.0, 1.0}).norm() + 2 + diagonal_time;
+    }
+
+    WHEN("Significant speed limit from 6 -> 7")
+    {
+      graph.get_lane(12).properties().speed_limit(0.1);
+      expected_path = {5, 4, 3, 8, 9};
+      expected_cost = 3.5 + diagonal_time;
+    }
+
+    WHEN("Significant speed limit on offset lane")
+    {
+      graph.get_lane(6).properties().speed_limit(0.1);
+      expected_path = {5, 4, 3, 8, 9};
+      expected_cost = 3.5 + diagonal_time;
+    }
+  }
+
+  GIVEN("Quickest Path Request for unreachable 1 -> 11")
+  {
+    start_set.push_back({time, 1, 0.0});
+    goal_wp = 11;
+    expected_cost = std::nullopt;
+  }
+
+  GIVEN("Quickest Path Request for reachable 11 -> 0")
+  {
+    start_set.push_back({time, 11, 0.0});
+    goal_wp = 0;
+    expected_path = {11, 9, 8, 3, 4, 0};
+    expected_cost = 5 + diagonal_time;
+  }
+
+  auto options = rmf_traffic::agv::Planner::Options{nullptr};
+  rmf_traffic::agv::Planner planner{
+    rmf_traffic::agv::Planner::Configuration{graph, traits},
+    options
+  };
+
+  auto quickest = planner.quickest_path(start_set, goal_wp);
+  if (expected_cost.has_value())
+  {
+    REQUIRE(quickest.has_value());
+    CHECK(quickest->cost() == *expected_cost);
+    CHECK(quickest->path() == expected_path);
+  }
+  else
+  {
+    CHECK_FALSE(quickest.has_value());
   }
 }
 


### PR DESCRIPTION
This PR adds a quickest_path feature for the planner. Asking for the quickest_path bypasses many of the normal capabilities of the planner to quickly give back an estimate of the quickest path to get between two points.