### PR TITLE
Fix culling and delay implementation

### DIFF
--- a/rmf_traffic/include/rmf_traffic/schedule/Database.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Database.hpp
@@ -209,6 +209,23 @@ public:
     const Query& parameters,
     Version after) const;
 
+  /// Excessive cumulative delays have a risk of overloading the schedule
+  /// database by taking up an excessive amount of memory to track the delay
+  /// history. Typically this would be a cumulative delay on the scale of
+  /// weeks, months, years, etc, and almost certainly indicates an error in
+  /// the schedule participant's reporting.
+  ///
+  /// Still, to avoid harmful effects of participant errors, when the database
+  /// detects an excessive cumulative delay for a participant, a new delay(~)
+  /// command will be converted into a set(~) command. This function lets you
+  /// decide what the threshold should be for that. The default is equivalent to
+  /// 2 hours.
+  void set_maximum_cumulative_delay(rmf_traffic::Duration maximum_delay);
+
+  /// Get the current cumulative delay for the participant.
+  std::optional<rmf_traffic::Duration> get_cumulative_delay(
+    ParticipantId participant) const;
+
   /// Throw away all itineraries up to the specified time.
   ///
   /// \param[in] time

--- a/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp
@@ -47,25 +47,40 @@ public:
   ///   The new itinerary that the participant should reflect in the schedule.
   bool set(PlanId plan, std::vector<Route> itinerary);
 
-  /// Add more routes for the participant. All of the routes currently in the
-  /// itinerary will still be in it.
+  /// The cumulative delay that has built up since the last call to
+  /// set(plan, ~). If plan does not match the current Plan ID of the itinerary
+  /// then this returns a nullopt.
   ///
-  /// \param[in] additional_routes
-  ///   The new routes to add to the itinerary.
-  void extend(std::vector<Route> additional_routes);
+  /// \note This value will not grow when there are no are itineraries for this
+  /// participant.
+  std::optional<Duration> cumulative_delay(PlanId plan) const;
+
+  /// Set the cumulative delay of the specified plan. Returns false if plan does
+  /// not match the current Plan ID of the itinerary.
+  /// \param[in] plan
+  ///   The unique plan ID that this cumulative delay is relevant for
+  ///
+  /// \param[in] delay
+  ///   The value for the cumulative delay
+  ///
+  /// \param[in] tolerance
+  ///   A tolerance threshold for reporting this delay. If the magnitude of
+  ///   change in the cumulative delay is less than or equal to the magnitude of
+  ///   this tolerance, then no change will be reported to the schedule. Use
+  ///   Duration(0) to always report any non-zero change in cumulative delay.
+  bool cumulative_delay(
+    PlanId plan,
+    Duration delay,
+    Duration tolerance = Duration(0));
 
   /// Delay the current itinerary.
   ///
   /// \param[in] delay
   ///   The amount of time to push back the relevant waypoints.
+  [[deprecated("Use cumulative_delay instead")]]
   void delay(Duration delay);
 
-  /// The cumulative delay that has built up since the last call to set().
-  ///
-  /// \note This value will not grow when there are no are itineraries for this
-  /// participant.
-  //
-  // TODO(MXG): Should extend() also reset this value? Currently it does not.
+  [[deprecated("Use cumulative_delay instead")]]
   Duration delay() const;
 
   /// Notify the schedule that a checkpoint within a plan has been reached

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -338,7 +338,7 @@ std::vector<Plan::Waypoint> find_dependencies(
                 ss << "-------------------------------------------------"
                    << "\n[rmf_traffic::agv::Planner::plan] WARNING: "
                    << "A rare anomaly has occurred in the planner. The Route "
-                   << "Validator has failed o recognize a specified route "
+                   << "Validator has failed to recognize a specified route "
                    << "dependency: " << dependent << " on {"
                    << dependency.on_participant << " " << dependency.on_plan
                    << " " << dependency.on_route << " "

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -298,7 +298,7 @@ std::vector<Plan::Waypoint> find_dependencies(
       std::unordered_map<CheckpointId, Dependencies> found_dependencies;
       while (!no_conflicts)
       {
-        if (++count > 10000)
+        if (++count > 100)
         {
           // This almost certainly means there's a bug causing an infinite loop.
           // A normal value would be less than 10.

--- a/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
@@ -1607,7 +1607,6 @@ Version Database::cull(Time time)
     // are recursively destructed. Therefore we will first store the
     // predecessors in a queue before erasing the entry, and then destruct the
     // queue in an order that will avoid recursive destruction.
-    std::cout << " ===== CULLING SCHEDULE ROUTE ENTRY" << std::endl;
     std::unordered_set<Implementation::RouteEntryPtr> visited;
     std::deque<Implementation::RouteEntryPtr> entries;
     entries.push_back(r_it->second.entry);
@@ -1617,7 +1616,10 @@ Version Database::cull(Time time)
       {
         if (!visited.insert(transition->predecessor.entry).second)
         {
-          throw std::runtime_error(" !!!! REVISITED ROUTE ENTRY -- CIRCULAR REFERENCE!");
+          // A circular reference like this should never happen, but if it does
+          // then we should exit right away.
+          // TODO(MXG): Consider escalating this issue with an error printout
+          break;
         }
         entries.push_back(transition->predecessor.entry);
       }

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -121,6 +121,22 @@ bool Participant::Implementation::Shared::cumulative_delay(
   if (std::chrono::abs(change_in_delay) <= std::chrono::abs(tolerance))
     return true;
 
+  bool no_delays = true;
+  for (auto& route : _current_itinerary)
+  {
+    if (route.trajectory().size() > 0)
+    {
+      no_delays = false;
+      route.trajectory().front().adjust_times(change_in_delay);
+    }
+  }
+
+  if (no_delays)
+  {
+    // We don't need to make any changes, because there are no waypoints to move
+    return true;
+  }
+
   _cumulative_delay = new_cumulative_delay;
   const ItineraryVersion itinerary_version = get_next_version();
   const ParticipantId id = _id;

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -73,6 +73,7 @@ bool Participant::Implementation::Shared::set(
 
   _change_history.clear();
   _cumulative_delay = std::chrono::seconds(0);
+  std::cout << "[" << _description.name() << "] cumulative delay reset by set: " << time::to_seconds(_cumulative_delay) << std::endl;
   _current_plan_id = plan;
   const auto storage_base = _next_storage_base;
   _next_storage_base += itinerary.size();
@@ -109,46 +110,46 @@ bool Participant::Implementation::Shared::set(
 }
 
 //==============================================================================
-void Participant::Implementation::Shared::extend(
-  std::vector<Route> additional_routes)
+bool Participant::Implementation::Shared::cumulative_delay(
+  PlanId plan,
+  Duration new_cumulative_delay,
+  Duration tolerance)
 {
-  for (std::size_t i = 0; i < additional_routes.size(); ++i)
-  {
-    const auto& r = additional_routes[i];
-    if (r.trajectory().size() < 2)
-    {
-      // *INDENT-OFF*
-      throw std::runtime_error(
-        "[Participant::extend] Route [" + std::to_string(i) + "] has a "
-        "trajectory of size [" + std::to_string(r.trajectory().size()) + "], "
-        "but the minimum acceptable size is 2.");
-      // *INDENT-ON*
-    }
-  }
+  if (plan != _current_plan_id)
+    return false;
 
-  if (additional_routes.empty())
-    return;
+  const auto change_in_delay = new_cumulative_delay - _cumulative_delay;
+  if (std::chrono::abs(change_in_delay) <= std::chrono::abs(tolerance))
+    return true;
 
-  _next_storage_base += additional_routes.size();
-  _current_itinerary.reserve(
-    _current_itinerary.size() + additional_routes.size());
+  std::cout << "[" << _description.name() << "] cumulative delay adjustment:"
+            << "\n -- before: " << time::to_seconds(_cumulative_delay)
+            << "\n -- after:  " << time::to_seconds(new_cumulative_delay)
+            << "\n -- change: " << time::to_seconds(change_in_delay);
 
-  for (const auto& item : additional_routes)
-    _current_itinerary.push_back(item);
-
-  _progress.resize(_current_itinerary.size());
-
+  _cumulative_delay = new_cumulative_delay;
   const ItineraryVersion itinerary_version = get_next_version();
   const ParticipantId id = _id;
   auto change =
-    [self = weak_from_this(), additional_routes, itinerary_version, id]()
+    [self = weak_from_this(), change_in_delay, itinerary_version, id]()
     {
       if (const auto me = self.lock())
-        me->_writer->extend(id, additional_routes, itinerary_version);
+        me->_writer->delay(id, change_in_delay, itinerary_version);
     };
 
   _change_history[itinerary_version] = change;
   change();
+  return true;
+}
+
+//==============================================================================
+std::optional<Duration> Participant::Implementation::Shared::cumulative_delay(
+  const PlanId plan) const
+{
+  if (plan == _current_plan_id)
+    return _cumulative_delay;
+
+  return std::nullopt;
 }
 
 //==============================================================================
@@ -170,6 +171,11 @@ void Participant::Implementation::Shared::delay(Duration delay)
     return;
   }
 
+  std::cout << "[" << _description.name() << "] delay adjustment:"
+            << "\n -- before: " << time::to_seconds(_cumulative_delay)
+            << "\n -- adjust: " << time::to_seconds(delay)
+            << "\n -- after:  " << time::to_seconds(_cumulative_delay + delay)
+            << std::endl;
   _cumulative_delay += delay;
 
   const ItineraryVersion itinerary_version = get_next_version();
@@ -208,6 +214,8 @@ void Participant::Implementation::Shared::reached(
 //==============================================================================
 void Participant::Implementation::Shared::clear()
 {
+  _cumulative_delay = std::chrono::seconds(0);
+  std::cout << "[" << _description.name() << "] cumulative delay reset by clear: " << time::to_seconds(_cumulative_delay) << std::endl;
   if (_current_itinerary.empty())
   {
     // There is nothing to clear, so we can skip this change
@@ -395,9 +403,16 @@ bool Participant::set(PlanId plan, std::vector<Route> itinerary)
 }
 
 //==============================================================================
-void Participant::extend(std::vector<Route> additional_routes)
+bool Participant::cumulative_delay(
+  PlanId plan, Duration delay, Duration tolerance)
 {
-  return _pimpl->_shared->extend(additional_routes);
+  return _pimpl->_shared->cumulative_delay(plan, delay, tolerance);
+}
+
+//==============================================================================
+std::optional<Duration> Participant::cumulative_delay(PlanId plan) const
+{
+  return _pimpl->_shared->cumulative_delay(plan);
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -73,7 +73,6 @@ bool Participant::Implementation::Shared::set(
 
   _change_history.clear();
   _cumulative_delay = std::chrono::seconds(0);
-  std::cout << "[" << _description.name() << "] cumulative delay reset by set: " << time::to_seconds(_cumulative_delay) << std::endl;
   _current_plan_id = plan;
   const auto storage_base = _next_storage_base;
   _next_storage_base += itinerary.size();
@@ -122,11 +121,6 @@ bool Participant::Implementation::Shared::cumulative_delay(
   if (std::chrono::abs(change_in_delay) <= std::chrono::abs(tolerance))
     return true;
 
-  std::cout << "[" << _description.name() << "] cumulative delay adjustment:"
-            << "\n -- before: " << time::to_seconds(_cumulative_delay)
-            << "\n -- after:  " << time::to_seconds(new_cumulative_delay)
-            << "\n -- change: " << time::to_seconds(change_in_delay);
-
   _cumulative_delay = new_cumulative_delay;
   const ItineraryVersion itinerary_version = get_next_version();
   const ParticipantId id = _id;
@@ -171,11 +165,6 @@ void Participant::Implementation::Shared::delay(Duration delay)
     return;
   }
 
-  std::cout << "[" << _description.name() << "] delay adjustment:"
-            << "\n -- before: " << time::to_seconds(_cumulative_delay)
-            << "\n -- adjust: " << time::to_seconds(delay)
-            << "\n -- after:  " << time::to_seconds(_cumulative_delay + delay)
-            << std::endl;
   _cumulative_delay += delay;
 
   const ItineraryVersion itinerary_version = get_next_version();
@@ -215,7 +204,6 @@ void Participant::Implementation::Shared::reached(
 void Participant::Implementation::Shared::clear()
 {
   _cumulative_delay = std::chrono::seconds(0);
-  std::cout << "[" << _description.name() << "] cumulative delay reset by clear: " << time::to_seconds(_cumulative_delay) << std::endl;
   if (_current_itinerary.empty())
   {
     // There is nothing to clear, so we can skip this change

--- a/rmf_traffic/src/rmf_traffic/schedule/internal_Participant.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/internal_Participant.hpp
@@ -49,7 +49,9 @@ public:
 
     bool set(PlanId plan, std::vector<Route> itinerary);
 
-    void extend(std::vector<Route> additional_routes);
+    bool cumulative_delay(PlanId plan, Duration delay, Duration tolerance);
+
+    std::optional<Duration> cumulative_delay(PlanId plan) const;
 
     void delay(Duration delay);
 

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -931,14 +931,15 @@ SCENARIO("A Single Lane")
         {vertex_id_to_idx["C"]}
       );
 
-      p0.set(p0.plan_id_assigner()->assign(), a0_plan_0->get_itinerary());
-
       const auto a0_plan_1 = a0_planner.plan(
         {time + 8s, vertex_id_to_idx["C"], 0.0},
         {vertex_id_to_idx["A"]}
       );
 
-      p0.extend(a0_plan_1->get_itinerary());
+      auto itinerary = a0_plan_0->get_itinerary();
+      auto extension = a0_plan_1->get_itinerary();
+      itinerary.insert(itinerary.end(), extension.begin(), extension.end());
+      p0.set(p0.plan_id_assigner()->assign(), itinerary);
 
       std::vector<CentralizedNegotiation::Agent> agents;
       agents.push_back(
@@ -1539,14 +1540,15 @@ SCENARIO("A single lane with an alcove holding space")
         {vertex_id_to_idx["A"]}
       );
 
-      p1.set(p1.plan_id_assigner()->assign(), a1_plan_0->get_itinerary());
-
       const auto a1_plan_1 = a1_planner.plan(
         {time + 16s, vertex_id_to_idx["A"], 0.0},
         {vertex_id_to_idx["D"]}
       );
 
-      p1.extend(a1_plan_1->get_itinerary());
+      auto itinerary = a1_plan_0->get_itinerary();
+      auto extension = a1_plan_1->get_itinerary();
+      itinerary.insert(itinerary.end(), extension.begin(), extension.end());
+      p1.set(p1.plan_id_assigner()->assign(), itinerary);
 
       std::vector<CentralizedNegotiation::Agent> agents;
       agents.push_back(

--- a/rmf_traffic/test/unit/schedule/test_Mirror.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Mirror.cpp
@@ -698,32 +698,17 @@ SCENARIO("Test forking off of mirrors")
 
   writer->drop_packets = true;
 
-  trajectory.insert(now + 20s, {10, 10, 0}, {0, 0, 0});
-  p0.extend({{test_map, trajectory}});
-
-  writer->drop_packets = false;
-
-  trajectory.insert(now + 22s, {10, 10, 0}, {0, 0, 0});
-  p0.extend({{test_map, trajectory}});
-
   writer->rectify();
 
-  p0.delay(10s);
+  p0.cumulative_delay(p0.current_plan_id(), 10s);
 
   writer->drop_packets = true;
 
-  trajectory.insert(now + 32s, {10, 0, 0}, {0, 0, 0});
-  p0.extend({{test_map, trajectory}});
-  p0.delay(5s);
+  p0.cumulative_delay(p0.current_plan_id(), 5s);
 
   writer->failover();
 
   writer->drop_packets = false;
-
-  trajectory.erase(trajectory.begin(), trajectory.end());
-  trajectory.insert(now, {3, 2, 1}, {0, 0, 0});
-  trajectory.insert(now + 10s, {1, 2, 3}, {0, 0, 0});
-  p0.extend({{test_map, trajectory}});
 
   writer->rectify();
 
@@ -751,10 +736,7 @@ SCENARIO("Test forking off of mirrors")
 
   trajectory.insert(now + 32s, {10, 0, 0}, {0, 0, 0});
   p0.set(p0.plan_id_assigner()->assign(), {{test_map, trajectory}});
-  p0.delay(20s);
-
-  trajectory.insert(now + 10s, {0, 10, 0}, {0, 0, 0});
-  p0.extend({{test_map, trajectory}});
+  p0.cumulative_delay(p0.current_plan_id(), 20s);
 
   writer->drop_packets = false;
   writer->rectify();

--- a/rmf_traffic/test/unit/schedule/test_Participant.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Participant.cpp
@@ -246,35 +246,9 @@ SCENARIO("Test Participant")
     CHECK_ITINERARY(p1, *db);
   }
 
-  GIVEN("Changes: X")
-  {
-    p1.extend({Route{"test_map", t1}});
-    CHECK(p1.itinerary().size() == 1);
-    CHECK(db->latest_version() == ++dbv);
-    CHECK_ITINERARY(p1, *db);
-  }
-
-  GIVEN("Changes: SX")
-  {
-    p1.set(p1.plan_id_assigner()->assign(), {Route{"test_map", t1}});
-    REQUIRE(p1.itinerary().size() == 1);
-    CHECK(db->latest_version() == ++dbv);
-    CHECK_ITINERARY(p1, *db);
-
-    // Extend itinerary with two new routes
-    std::vector<Route> additional_routes;
-    additional_routes.emplace_back(Route{"test_map", t2});
-    additional_routes.emplace_back(Route{"test_map_2", t1});
-
-    p1.extend(additional_routes);
-    CHECK(p1.itinerary().size() == 3);
-    CHECK(db->latest_version() == ++dbv);
-    CHECK_ITINERARY(p1, *db);
-  }
-
   GIVEN("Changes: D")
   {
-    p1.delay(5s);
+    p1.cumulative_delay(p1.current_plan_id(), 5s);
     CHECK(p1.itinerary().size() == 0);
     CHECK(p1.current_plan_id() ==
       std::numeric_limits<rmf_traffic::PlanId>::max());
@@ -294,7 +268,7 @@ SCENARIO("Test Participant")
     const auto old_itinerary = p1.itinerary();
 
     const auto delay_duration = 5s;
-    p1.delay(delay_duration);
+    p1.cumulative_delay(p1.current_plan_id(), delay_duration);
     REQUIRE(p1.itinerary().size() == 1);
 
     auto old_it = old_itinerary.front().trajectory().begin();
@@ -387,7 +361,7 @@ SCENARIO("Test Participant")
 
     writer->drop_packets = false;
 
-    p1.delay(10s);
+    p1.cumulative_delay(p1.current_plan_id(), 10s);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->inconsistencies().size() == 1);
     CHECK(db->inconsistencies().begin()->ranges.size() == 1);
@@ -396,7 +370,7 @@ SCENARIO("Test Participant")
 
     writer->drop_packets = true;
 
-    p1.delay(10s);
+    p1.cumulative_delay(p1.current_plan_id(), 10s);
     CHECK(db->latest_version() == dbv);
     CHECK(db->inconsistencies().begin()->ranges.last_known_version() + 1 ==
       rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
@@ -668,33 +642,7 @@ SCENARIO("Test Participant")
     CHECK_FALSE(watch_4_3_2.deprecated());
   }
 
-  GIVEN("Changes: sX")
-  {
-    writer->drop_packets = true;
-
-    // Set the itinerary
-    p1.set(
-      p1.plan_id_assigner()->assign(),
-      {Route{"test_map", t1}, Route{"test_map", t2}});
-    CHECK(db->latest_version() == dbv);
-
-    writer->drop_packets = false;
-
-    // Extend the itinerary
-    p1.extend({Route{"test_map_2", t2}});
-    REQUIRE(db->get_itinerary(p1.id()));
-    CHECK(db->get_itinerary(p1.id())->size() == 0);
-    CHECK(db->inconsistencies().begin()->participant == p1.id());
-    CHECK(db->inconsistencies().begin()->ranges.size() != 0);
-
-    // Fix inconsistencies
-    rectifier->rectify();
-    CHECK(db->latest_version() == ++(++dbv));
-    CHECK_ITINERARY(p1, *db);
-    CHECK(db->inconsistencies().begin()->ranges.size() == 0);
-  }
-
-  GIVEN("Changes: SxX")
+  GIVEN("Changes: SdD")
   {
     p1.set(
       p1.plan_id_assigner()->assign(),
@@ -706,14 +654,14 @@ SCENARIO("Test Participant")
     // Tell the writer to start dropping packets
     writer->drop_packets = true;
 
-    p1.extend({Route{"test_map_2", t1}});
+    p1.cumulative_delay(p1.current_plan_id(), 5s);
 
     // Check that the database version did not change
     CHECK(db->latest_version() == dbv);
 
     writer->drop_packets = false;
 
-    p1.extend({Route{"test_map_3", t1}});
+    p1.cumulative_delay(p1.current_plan_id(), 7s);
 
     // Check that the database version still did not change
     CHECK(db->latest_version() == dbv);
@@ -735,7 +683,7 @@ SCENARIO("Test Participant")
     CHECK(db->inconsistencies().begin()->ranges.size() == 0);
   }
 
-  GIVEN("Changes: sddxX")
+  GIVEN("Changes: sdddD")
   {
     writer->drop_packets = true;
 
@@ -747,21 +695,21 @@ SCENARIO("Test Participant")
     CHECK(db->get_itinerary(p1.id())->empty());
 
     // Add a delay to the itinerary
-    p1.delay(1s);
+    p1.cumulative_delay(p1.current_plan_id(), 1s);
     CHECK(p1.itinerary().size() == 1);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->get_itinerary(p1.id()));
     CHECK(db->get_itinerary(p1.id())->empty());
 
     // Add a second delay to the itinerary
-    p1.delay(1s);
+    p1.cumulative_delay(p1.current_plan_id(), 2s);
     CHECK(p1.itinerary().size() == 1);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->get_itinerary(p1.id()));
     CHECK(db->get_itinerary(p1.id())->empty());
 
     // Extend the itinerary
-    p1.extend({Route{"test_map", t2}, Route{"test_map", t3}});
+    p1.cumulative_delay(p1.current_plan_id(), -3s);
     CHECK(p1.itinerary().size() == 3);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->get_itinerary(p1.id()));
@@ -770,7 +718,7 @@ SCENARIO("Test Participant")
     writer->drop_packets = false;
 
     // Extend the itinerary
-    p1.extend({Route{"test_map_2", t3}});
+    p1.cumulative_delay(p1.current_plan_id(), -5s);
     CHECK(p1.itinerary().size() == 4);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->get_itinerary(p1.id()));
@@ -793,7 +741,7 @@ SCENARIO("Test Participant")
     CHECK(db->inconsistencies().begin()->ranges.size() == 0);
   }
 
-  GIVEN("Changes: SdDxX")
+  GIVEN("Changes: SdDdD")
   {
     // Set the participant itinerary
     p1.set(p1.plan_id_assigner()->assign(), {Route{"test_map", t1}});
@@ -804,13 +752,13 @@ SCENARIO("Test Participant")
     writer->drop_packets = true;
 
     // Add a delay
-    p1.delay(1s);
+    p1.cumulative_delay(p1.current_plan_id(), 1s);
     CHECK(db->latest_version() == dbv);
 
     writer->drop_packets = false;
 
     // Add a delay
-    p1.delay(1s);
+    p1.cumulative_delay(p1.current_plan_id(), -1s);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->inconsistencies().size() > 0);
     auto inconsistency = db->inconsistencies().begin();
@@ -823,14 +771,14 @@ SCENARIO("Test Participant")
     writer->drop_packets = true;
 
     // Extend the itinerary
-    p1.extend({Route{"test_map", t2}});
+    p1.cumulative_delay(p1.current_plan_id(), -5s);
     CHECK(p1.itinerary().size() == 2);
     CHECK(db->latest_version() == dbv);
 
     writer->drop_packets = false;
 
     // Extend the itinerary
-    p1.extend({Route{"test_map", t3}});
+    p1.cumulative_delay(p1.current_plan_id(), 0s);
     REQUIRE(db->inconsistencies().size() > 0);
     CHECK(db->inconsistencies().begin()->participant == p1.id());
     inconsistency = db->inconsistencies().begin();
@@ -853,7 +801,7 @@ SCENARIO("Test Participant")
     CHECK(db->inconsistencies().begin()->ranges.size() == 0);
   }
 
-  GIVEN("Changes: ScX")
+  GIVEN("Changes: Sc")
   {
     // Set the participant itinerary
     p1.set(p1.plan_id_assigner()->assign(), {Route{"test_map", t1}});
@@ -872,20 +820,6 @@ SCENARIO("Test Participant")
 
     writer->drop_packets = false;
 
-    // Extend the itinerary
-    p1.extend({Route{"test_map", t2}, Route{"test_map", t3}});
-    REQUIRE(p1.itinerary().size() == 2);
-    CHECK(db->latest_version() == dbv);
-
-    // Check for inconsistencies
-    REQUIRE(db->inconsistencies().size() == 1);
-    auto inconsistency = db->inconsistencies().begin();
-    CHECK(inconsistency->participant == p1.id());
-    REQUIRE(inconsistency->ranges.size() > 0);
-    CHECK(inconsistency->ranges.last_known_version() == 2);
-    CHECK(inconsistency->ranges.begin()->lower == 1);
-    CHECK(inconsistency->ranges.begin()->upper == 1);
-
     // Fix inconsistency
     rectifier->rectify();
     dbv += 2;
@@ -896,7 +830,6 @@ SCENARIO("Test Participant")
 
   GIVEN("Participant unregisters")
   {
-
     rmf_traffic::schedule::ParticipantId p2_id;
 
     {

--- a/rmf_traffic/test/unit/schedule/test_Participant.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Participant.cpp
@@ -372,6 +372,12 @@ SCENARIO("Test Participant")
 
     p1.cumulative_delay(p1.current_plan_id(), 10s);
     CHECK(db->latest_version() == dbv);
+    // No change because the new cumulative delay is equal to the previous one
+    CHECK(db->inconsistencies().begin()->ranges.last_known_version() ==
+      rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
+
+    p1.cumulative_delay(p1.current_plan_id(), 9s);
+    CHECK(db->latest_version() == dbv);
     CHECK(db->inconsistencies().begin()->ranges.last_known_version() + 1 ==
       rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
 
@@ -677,7 +683,7 @@ SCENARIO("Test Participant")
     // Now the database should have updated with both changes
     CHECK(db->latest_version() == ++(++dbv));
     REQUIRE(db->get_itinerary(p1.id()));
-    CHECK(db->get_itinerary(p1.id())->size() == 3);
+    CHECK(db->get_itinerary(p1.id())->size() == 1);
     const auto itinerary = db->get_itinerary(p1.id());
     CHECK_ITINERARY(p1, *db);
     CHECK(db->inconsistencies().begin()->ranges.size() == 0);
@@ -710,7 +716,7 @@ SCENARIO("Test Participant")
 
     // Extend the itinerary
     p1.cumulative_delay(p1.current_plan_id(), -3s);
-    CHECK(p1.itinerary().size() == 3);
+    CHECK(p1.itinerary().size() == 1);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->get_itinerary(p1.id()));
     CHECK(db->get_itinerary(p1.id())->empty());
@@ -719,7 +725,7 @@ SCENARIO("Test Participant")
 
     // Extend the itinerary
     p1.cumulative_delay(p1.current_plan_id(), -5s);
-    CHECK(p1.itinerary().size() == 4);
+    CHECK(p1.itinerary().size() == 1);
     CHECK(db->latest_version() == dbv);
     REQUIRE(db->get_itinerary(p1.id()));
     CHECK(db->get_itinerary(p1.id())->empty());
@@ -772,7 +778,7 @@ SCENARIO("Test Participant")
 
     // Extend the itinerary
     p1.cumulative_delay(p1.current_plan_id(), -5s);
-    CHECK(p1.itinerary().size() == 2);
+    CHECK(p1.itinerary().size() == 1);
     CHECK(db->latest_version() == dbv);
 
     writer->drop_packets = false;
@@ -822,7 +828,7 @@ SCENARIO("Test Participant")
 
     // Fix inconsistency
     rectifier->rectify();
-    dbv += 2;
+    dbv += 1;
     CHECK(db->latest_version() == dbv);
     CHECK_ITINERARY(p1, *db);
     CHECK(db->inconsistencies().begin()->ranges.size() == 0);

--- a/rmf_traffic/test/unit/schedule/utils_Database.hpp
+++ b/rmf_traffic/test/unit/schedule/utils_Database.hpp
@@ -32,7 +32,7 @@
 #include <rmf_utils/catch.hpp>
 
 //==============================================================================
-inline void CHECK_EQUAL_TRAJECTORY(
+inline bool check_equal_trajectory(
   const rmf_traffic::Trajectory& t1,
   const rmf_traffic::Trajectory& t2)
 {
@@ -45,25 +45,67 @@ inline void CHECK_EQUAL_TRAJECTORY(
   auto t1_it = t1.begin();
   auto t2_it = t2.begin();
 
+  bool test_passes = true;
   for (; t1_it != t1.end(); ++t1_it, ++t2_it)
   {
-    CHECK((t1_it->position() - t2_it->position()).norm() == Approx(0.0).margin(
-        1e-6));
-    CHECK((t1_it->velocity() - t2_it->velocity()).norm() == Approx(0.0).margin(
-        1e-6));
-    CHECK((t1_it->time() - t2_it->time()).count() == Approx(0.0));
+    const bool positions_match =
+      (t1_it->position() - t2_it->position()).norm()
+        == Approx(0.0).margin(1e-6);
+    CHECK(positions_match);
+    if (!positions_match)
+    {
+      std::cout << t1_it->position().transpose() << " vs\n"
+                << t2_it->position().transpose() << std::endl;
+    }
+
+    const bool velocities_match =
+      (t1_it->velocity() - t2_it->velocity()).norm()
+        == Approx(0.0).margin(1e-6);
+    CHECK(velocities_match);
+    if (!velocities_match)
+    {
+      std::cout << t1_it->velocity().transpose() << " vs\n"
+                << t2_it->velocity().transpose() << std::endl;
+    }
+
+    const bool times_match =
+      (t1_it->time() - t2_it->time()).count() == Approx(0.0);
+    CHECK(times_match);
+    if (!times_match)
+    {
+      std::cout << t1_it->time().time_since_epoch().count() << " vs\n"
+                << t2_it->time().time_since_epoch().count() << std::endl;
+    }
+
+    test_passes &= positions_match && velocities_match && times_match;
   }
+
+  return test_passes;
 }
 
-inline void CHECK_TRAJECTORY_COUNT(
+inline bool check_trajectory_count(
   const rmf_traffic::schedule::Viewer& d,
   const std::size_t expected_participant_num,
   const std::size_t expected_trajectory_num)
 {
   const auto view = d.query(rmf_traffic::schedule::query_all());
-  CHECK(view.size() == expected_trajectory_num);
-  CHECK(d.participant_ids().size() == expected_participant_num);
+  const bool correct_trajectory_num = view.size() == expected_trajectory_num;
+  CHECK(correct_trajectory_num);
+
+  const bool correct_participant_num =
+    d.participant_ids().size() == expected_participant_num;
+  CHECK(correct_participant_num);
+
+  return correct_trajectory_num && correct_participant_num;
 }
+
+#define CHECK_TRAJECTORY_COUNT( \
+  d, expected_participant_num, expected_trajectory_num) \
+  { \
+    const bool trajectory_count_valid = check_trajectory_count( \
+      d, expected_participant_num, expected_trajectory_num); \
+    CHECK(trajectory_count_valid); \
+  }
 
 inline std::vector<rmf_traffic::Trajectory> get_conflicting_trajectories(
   const rmf_traffic::schedule::Viewer::View& view,
@@ -87,22 +129,38 @@ using RouteId = rmf_traffic::RouteId;
 using ConstRoutePtr = rmf_traffic::ConstRoutePtr;
 
 //==============================================================================
-inline void CHECK_ITINERARY(
+inline bool check_itinerary(
   const rmf_traffic::schedule::Participant& p,
   const rmf_traffic::schedule::Database& db)
 {
   const auto database_itinerary = db.get_itinerary(p.id());
   REQUIRE(database_itinerary.has_value());
   REQUIRE(p.itinerary().size() == database_itinerary->size());
+  bool test_passed = true;
   for (std::size_t i = 0; i < p.itinerary().size(); ++i)
   {
     const auto& database_route = database_itinerary->at(i);
     const auto& participant_route = p.itinerary().at(i);
-    CHECK(database_route->map() == participant_route.map());
-    CHECK_EQUAL_TRAJECTORY(
-      database_route->trajectory(), participant_route.trajectory());
+
+    const auto map_matches = database_route->map() == participant_route.map();
+    CHECK(map_matches);
+
+    const auto trajectory_matches = check_equal_trajectory(
+      participant_route.trajectory(), database_route->trajectory());
+    CHECK(trajectory_matches);
+
+    test_passed &= map_matches && trajectory_matches;
   }
+
+  return test_passed;
 }
+
+//==============================================================================
+#define CHECK_ITINERARY(p, db) \
+  { \
+    const bool itinerary_valid = check_itinerary(p, db); \
+    CHECK(itinerary_valid); \
+  }
 
 //==============================================================================
 inline rmf_traffic::schedule::Itinerary create_test_input(


### PR DESCRIPTION
During intensive long-run testing, it was discovered that bad inputs from schedule participants can lead to harmful behavior in the traffic schedule. This PR helps in two ways

* Excessive cumulative delays for schedule participants trigger the creation of new routes within the timeline storage so that older route information can be safely culled in a reasonable time.
* The Participant API was changed to make it much easier to correctly set the cumulative delay, even in heavily async code.