### PR TITLE
Fix multi floor anomaly

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -365,13 +365,6 @@ std::vector<Plan::Waypoint> find_dependencies(
                 assert(!checkpoint_map.empty());
                 // Find the closest route waypoint less than or equal to
                 // `dependent` that is associated with a plan waypoint.
-                std::cout << __LINE__ << ": dependent " << dependent << std::endl;
-                std::cout << __LINE__ << ": checkpoint map";
-                for (auto [c, p] : checkpoint_map)
-                {
-                  std::cout << " (" << c << ", " << p << ")";
-                }
-                std::cout << std::endl;
                 auto c_it = checkpoint_map.upper_bound(dependent);
                 if (c_it == checkpoint_map.begin())
                 {
@@ -384,7 +377,6 @@ std::vector<Plan::Waypoint> find_dependencies(
                 }
 
                 --c_it;
-                std::cout << __LINE__ << ": " << c_it->first << ", " << c_it->second << std::endl;
                 route.add_dependency(c_it->first, dependency);
 
                 return c_it->second;
@@ -392,8 +384,6 @@ std::vector<Plan::Waypoint> find_dependencies(
 
               if (wp.has_value())
               {
-                std::cout << *wp << std::endl;
-                std::cout << " ---------------- " << std::endl;
                 candidates[*wp].waypoint.dependencies.push_back(dependency);
                 candidates[*wp].necessary = true;
               }

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -289,6 +289,9 @@ std::vector<Plan::Waypoint> find_dependencies(
     {
       auto& route = itinerary[i];
       auto& checkpoint_map = checkpoint_maps[i];
+      if (checkpoint_map.empty())
+        continue;
+
       assert(route.trajectory().start_time());
       const auto initial_time = *route.trajectory().start_time();
 
@@ -357,19 +360,50 @@ std::vector<Plan::Waypoint> find_dependencies(
 
               no_conflicts = false;
               found_deps.push_back(dependency);
-              const auto wp = [&]()
+              const auto wp = [&]() -> std::optional<CheckpointId>
               {
                 assert(!checkpoint_map.empty());
                 // Find the closest route waypoint less than or equal to
                 // `dependent` that is associated with a plan waypoint.
-                const auto c_it = --checkpoint_map.upper_bound(dependent);
+                std::cout << __LINE__ << ": dependent " << dependent << std::endl;
+                std::cout << __LINE__ << ": checkpoint map";
+                for (auto [c, p] : checkpoint_map)
+                {
+                  std::cout << " (" << c << ", " << p << ")";
+                }
+                std::cout << std::endl;
+                auto c_it = checkpoint_map.upper_bound(dependent);
+                if (c_it == checkpoint_map.begin())
+                {
+                  // If the upper bound is the first element in the checkpoint
+                  // map, then the real dependent is the previous route of this
+                  // plan. We don't have a way to express that in today's RMF,
+                  // so instead we will set the first checkpoint of this route
+                  // as a dependent and then skip further dependency checking.
+                  return std::nullopt;
+                }
+
+                --c_it;
+                std::cout << __LINE__ << ": " << c_it->first << ", " << c_it->second << std::endl;
                 route.add_dependency(c_it->first, dependency);
 
                 return c_it->second;
               } ();
 
-              candidates[wp].waypoint.dependencies.push_back(dependency);
-              candidates[wp].necessary = true;
+              if (wp.has_value())
+              {
+                std::cout << *wp << std::endl;
+                std::cout << " ---------------- " << std::endl;
+                candidates[*wp].waypoint.dependencies.push_back(dependency);
+                candidates[*wp].necessary = true;
+              }
+              else
+              {
+                candidates.front().waypoint.dependencies.push_back(dependency);
+                candidates.front().necessary = true;
+                anomaly_happened = true;
+                break;
+              }
             }
           }
         }


### PR DESCRIPTION
We've found that an edge case can happen in multi-floor traffic negotiations when a traffic dependency exists between floors.

This PR prevents the edge case from derailing the whole fleet adapter, but it does not perfectly fix the underlying problem. A better fix would push the traffic dependency back to the prior route in the plan, but the implementation of plans+routes in `rmf_traffic` do not currently have a rigorous way of expressing an execution order, so there isn't a clean way to push the dependency back.

Since map changes are only expected to happen in lifts, which are currently single-occupancy 