### PR TITLE
Fix undefined behavior in plan cleanup

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -220,9 +220,11 @@ std::vector<NodePtr> reconstruct_nodes(
       else
         last_midlane_node = node;
     }
-
-    const auto wp = *node->waypoint;
-    cruft_map[wp].insert(node);
+    else
+    {
+      const auto wp = *node->waypoint;
+      cruft_map[wp].insert(node);
+    }
   }
 
   if (first_midlane_node && last_midlane_node)


### PR DESCRIPTION
This PR fixes some undefined behavior that can happen when trying to remove unnecessary motions from a plan. We were accidentally dereferencing an `optional` that may have a `nullopt` value.