### PR TITLE
Insert in-place rotation waypoint if missing

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
@@ -215,7 +215,7 @@ public:
     std::optional<double> merge_radius() const;
 
     /// Set the merge radius specific to this waypoint.
-    Waypoint& set_merge_radius(std::optional<double> valeu);
+    Waypoint& set_merge_radius(std::optional<double> value);
 
     class Implementation;
   private:

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -554,12 +554,12 @@ reconstruct_waypoints(
 
     // Insert in-place rotation waypoint if the current and previous waypoints
     // are disconnected
-    const auto prev_candidate = candidates.back();
-    const auto prev_wp = prev_candidate.waypoint;
-    const auto current_wp = node->waypoint;
+    const auto& prev_candidate = candidates.back();
+    const auto& prev_wp = prev_candidate.waypoint;
+    const auto& current_wp = node->waypoint;
     const bool same_stack =
       prev_wp.graph_index.has_value() && current_wp.has_value()
-      && *prev_wp.graph_index == *current_wp;
+      && prev_wp.graph_index == current_wp;
     const Eigen::Vector2d prev_pos =
       Eigen::Vector2d{prev_wp.position[0], prev_wp.position[1]};
     const bool same_pos = (prev_pos - node->position).norm() < 1e-3;

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -281,6 +281,12 @@ void stream_trajectory(
 }
 
 //==============================================================================
+inline bool same_orientation(double yaw0, double yaw1)
+{
+  return std::abs(rmf_utils::wrap_to_pi(yaw0 - yaw1))*180.0 / M_PI < 1e-2;
+}
+
+//==============================================================================
 std::vector<Plan::Waypoint> find_dependencies(
   std::vector<Route>& itinerary,
   std::vector<WaypointCandidate> candidates,
@@ -473,6 +479,72 @@ std::vector<Plan::Waypoint> find_dependencies(
     }
   }
 
+  std::size_t c_last = 0;
+  std::size_t c = 1;
+  std::size_t c_next = 2;
+  for (; c_next < candidates.size(); ++c_last, ++c, ++c_next)
+  {
+    auto& candidate = candidates[c];
+    if (candidate.waypoint.arrival.empty())
+    {
+      // This was a manually inserted turn-in-place, so let's try to match it
+      // with a trajectory checkpoint
+      const auto p_candidate = candidate.waypoint.position;
+      for (std::size_t r = 0; r < itinerary.size(); ++r)
+      {
+        std::optional<std::size_t> floor_opt;
+        for (const auto& checkpoint : candidates[c_last].waypoint.arrival)
+        {
+          if (checkpoint.route_id != r)
+            continue;
+
+          const auto id = checkpoint.checkpoint_id;
+          if (!floor_opt.has_value())
+            floor_opt = id;
+          else if (*floor_opt < id)
+            floor_opt = id;
+        }
+
+        if (!floor_opt.has_value())
+          continue;
+        const auto floor_id = floor_opt.value();
+
+        std::optional<std::size_t> ceil_opt;
+        for (const auto& checkpoint : candidates[c_next].waypoint.arrival)
+        {
+          if (checkpoint.route_id != r)
+            continue;
+
+          const auto id = checkpoint.checkpoint_id;
+          if (!ceil_opt.has_value())
+            ceil_opt = id;
+          else if (id < *ceil_opt)
+            ceil_opt = id;
+        }
+
+        if (!ceil_opt.has_value())
+          continue;
+        const auto ceil_id = ceil_opt.value();
+
+        // Between the floor and the ceiling, try to find a waypoint in this
+        // trajectory that matches the position of the inserted waypoint.
+        for (std::size_t id = floor_id; id < ceil_id; ++id)
+        {
+          const auto& trajectory_checkpoint = itinerary[r].trajectory()[id];
+          const auto p_trajectory = trajectory_checkpoint.position();
+          const bool same_pos = (p_candidate.block<2,1>(0,0) - p_trajectory.block<2,1>(0,0)).norm() < 1e-2;
+          const bool same_ori = same_orientation(p_candidate[2], p_trajectory[2]);
+          if (same_pos && same_ori)
+          {
+            // We have a matching checkpoint
+            candidate.waypoint.arrival.push_back(Plan::Checkpoint { r, id });
+            candidate.waypoint.time = trajectory_checkpoint.time();
+          }
+        }
+      }
+    }
+  }
+
   std::vector<Plan::Waypoint> waypoints;
   waypoints.reserve(candidates.size());
   for (const auto& c : candidates)
@@ -556,12 +628,10 @@ reconstruct_waypoints(
     // are disconnected
     const auto& prev_candidate = candidates.back();
     const auto& prev_wp = prev_candidate.waypoint;
-    const auto& current_wp = node->waypoint;
     const Eigen::Vector2d prev_pos =
       Eigen::Vector2d{prev_wp.position[0], prev_wp.position[1]};
     const bool same_pos = (prev_pos - node->position).norm() < 1e-3;
-    const bool same_ori =
-      std::abs(prev_wp.position[2] - node->yaw)*180.0 / M_PI < 1e-2;
+    const bool same_ori = same_orientation(prev_wp.position[2], node->yaw);
     if (!same_pos && !same_ori)
     {
       candidates.push_back(WaypointCandidate{
@@ -569,7 +639,7 @@ reconstruct_waypoints(
         Plan::Waypoint::Implementation{
           Eigen::Vector3d{prev_pos[0],  prev_pos[1], node->yaw},
           prev_wp.time, prev_wp.graph_index,
-          prev_wp.approach_lanes, {}, {}, prev_wp.event, {}
+          {}, {}, {}, prev_wp.event, {}
         },
         prev_candidate.velocity
       });

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -551,6 +551,33 @@ reconstruct_waypoints(
   {
     const auto& node = node_sequence.at(i);
     const auto yaw = node->yaw;
+
+    // Insert in-place rotation waypoint if the current and previous waypoints
+    // are disconnected
+    const auto prev_candidate = candidates.back();
+    const auto prev_wp = prev_candidate.waypoint;
+    const auto current_wp = node->waypoint;
+    const bool same_stack =
+      prev_wp.graph_index.has_value() && current_wp.has_value()
+      && *prev_wp.graph_index == *current_wp;
+    const Eigen::Vector2d prev_pos =
+      Eigen::Vector2d{prev_wp.position[0], prev_wp.position[1]};
+    const bool same_pos = (prev_pos - node->position).norm() < 1e-3;
+    const bool same_ori =
+      std::abs(prev_wp.position[2] - node->yaw)*180.0 / M_PI < 1e-2;
+    if (!(same_stack || same_pos) && !same_ori)
+    {
+      candidates.push_back(WaypointCandidate{
+        true,
+        Plan::Waypoint::Implementation{
+          Eigen::Vector3d{prev_pos[0],  prev_pos[1], node->yaw},
+          prev_wp.time, prev_wp.graph_index,
+          prev_wp.approach_lanes, {}, {}, prev_wp.event, {}
+        },
+        prev_candidate.velocity
+      });
+    }
+
     if (node->approach_lanes.empty())
     {
       // This means we are doing an in-place rotation or a wait

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -557,15 +557,12 @@ reconstruct_waypoints(
     const auto& prev_candidate = candidates.back();
     const auto& prev_wp = prev_candidate.waypoint;
     const auto& current_wp = node->waypoint;
-    const bool same_stack =
-      prev_wp.graph_index.has_value() && current_wp.has_value()
-      && prev_wp.graph_index == current_wp;
     const Eigen::Vector2d prev_pos =
       Eigen::Vector2d{prev_wp.position[0], prev_wp.position[1]};
     const bool same_pos = (prev_pos - node->position).norm() < 1e-3;
     const bool same_ori =
       std::abs(prev_wp.position[2] - node->yaw)*180.0 / M_PI < 1e-2;
-    if (!(same_stack || same_pos) && !same_ori)
+    if (!same_pos && !same_ori)
     {
       candidates.push_back(WaypointCandidate{
         true,


### PR DESCRIPTION
This PR targets https://github.com/open-rmf/rmf/issues/556 where in-place rotation commands for certain paths are missing. After tracing the fleet adapter and `rmf_traffic` planner, it seems the planner sometimes fails to provide these waypoints. These in-place rotation waypoints may be essential for AGVs that rely entirely on RMF to align towards their next destination. The fix implemented is to check for such gaps inside `reconstruct_waypoints` and insert the rotation command as needed.

**Test the fix**

The issue can be consistently reproduced in the Office demos world by sending a patrol command for `tinyRobot1` to `hardware_2`. Do set the `skip_rotation_commands` param to `False` when testing.

When the robot is returning from `hardware_2` to its charger, it would provide the following path:

```
[tinyRobot_fleet_adapter]: Executing final go_to_place [tinyRobot1_charger] for robot [tinyRobot/tinyRobot1]
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 20.89365413 -10.3083739   -1.59019108] on map [L1]: cmd_id 14
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 20.89365413 -10.3083739   -3.11109903] on map [L1]: cmd_id 15
[tinyRobot_fleet_adapter]: Opening door [hardware_door] for [tinyRobot/tinyRobot1]
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 18.79442303 -10.3724069   -3.11109903] on map [L1]: cmd_id 16
[tinyRobot_fleet_adapter]: Releasing door [hardware_door] for [tinyRobot/tinyRobot1]
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [18.73952429 -6.87398187 -1.5551052 ] on map [L1]: cmd_id 17
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 1.87395243e+01 -6.87398187e+00  3.91881687e-03] on map [L1]: cmd_id 18
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 1.68558247e+01 -6.88136378e+00  3.91881687e-03] on map [L1]: cmd_id 19
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [11.5658893  -6.99680773  0.0182071 ] on map [L1]: cmd_id 20
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [11.5658893  -6.99680773 -0.01173879] on map [L1]: cmd_id 21
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [10.08614619 -6.97943654 -0.01173879] on map [L1]: cmd_id 22
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [10.08614619 -6.97943654  1.32861949] on map [L1]: cmd_id 23
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [10.4330537  -5.57509559  1.32861949] on map [L1]: cmd_id 24
[tinyRobot_fleet_adapter]: Charging [tinyRobot/tinyRobot1] to [100.000000]
```
Notice the consecutive commands provided to the fleet adapter with `cmd_id` 19 and 20 have neither the same location nor yaw. path provided to the fleet adapter goes from 

With this PR, an intermediate rotation waypoint (`cmd_id` 20) will be inserted and provided to the fleet adapter:
```
[tinyRobot_fleet_adapter]: Executing final go_to_place [tinyRobot1_charger] for robot [tinyRobot/tinyRobot1]
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 20.89365413 -10.3083739   -1.59019246] on map [L1]: cmd_id 14
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 20.89365413 -10.3083739   -3.11109903] on map [L1]: cmd_id 15
[tinyRobot_fleet_adapter]: Opening door [hardware_door] for [tinyRobot/tinyRobot1]
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 18.79442303 -10.3724069   -3.11109903] on map [L1]: cmd_id 16
[tinyRobot_fleet_adapter]: Releasing door [hardware_door] for [tinyRobot/tinyRobot1]
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [18.73952429 -6.87398187 -1.5551052 ] on map [L1]: cmd_id 17
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 1.87395243e+01 -6.87398187e+00  3.91881687e-03] on map [L1]: cmd_id 18
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [ 1.68558247e+01 -6.88136378e+00  3.91881687e-03] on map [L1]: cmd_id 19
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [16.85582469 -6.88136378  0.0182071 ] on map [L1]: cmd_id 20
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [11.5658893  -6.99680773  0.0182071 ] on map [L1]: cmd_id 21
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [11.5658893  -6.99680773 -0.01173879] on map [L1]: cmd_id 22
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [10.08614619 -6.97943654 -0.01173879] on map [L1]: cmd_id 23
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [10.08614619 -6.97943654  1.32861949] on map [L1]: cmd_id 24
[tinyRobot_command_handle]: Commanding [tinyRobot1] to navigate to [10.4330537  -5.57509559  1.32861949] on map [L1]: cmd_id 25
[tinyRobot_fleet_adapter]: Charging [tinyRobot/tinyRobot1] to [100.000000]
```