### PR TITLE
Use waypoint merge radius override when computing plan starts

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -1169,8 +1169,10 @@ std::vector<Plan::Start> compute_plan_starts(
       continue;
 
     const Eigen::Vector2d wp_location = wp.get_location();
+    const auto merge_radius =
+      wp.merge_radius().value_or(max_merge_waypoint_distance);
 
-    if ( (p_location - wp_location).norm() < max_merge_waypoint_distance)
+    if ( (p_location - wp_location).norm() < merge_radius)
     {
       return {Plan::Start(start_time, wp.index(), start_yaw)};
     }


### PR DESCRIPTION
Related to https://github.com/open-rmf/rmf/discussions/631 we are not currently using the `merge_radius` vertex property when calculating whether we should consider a robot to be _**on**_ a vertex.

This PR fixes that so the behavior matches what a user would expect.