### PR TITLE
Immeidately mark dependencies as deprecated when the target plan was cleared

### DIFF
--- a/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
@@ -1405,6 +1405,14 @@ auto Database::watch_dependency(
 
   if (state.latest_plan_id == dep.on_plan)
   {
+    if (state.storage.empty())
+    {
+      // This plan has already been cleared from the schedule, so any
+      // dependencies on it are deprecated.
+      shared->deprecate();
+      return subscription;
+    }
+
     if (dep.on_route < state.progress.reached_checkpoints.size())
     {
       const auto latest_checkpoint =

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -345,6 +345,14 @@ auto Mirror::watch_dependency(
 
   if (state.current_plan_id == dep.on_plan)
   {
+    if (state.storage.empty())
+    {
+      // This plan has already been cleared from the schedule, so any
+      // dependencies on it are deprecated.
+      shared->deprecate();
+      return subscription;
+    }
+
     if (dep.on_route < state.progress.reached_checkpoints.size())
     {
       const auto latest_checkpoint =


### PR DESCRIPTION
This should resolve the issue report [here](https://github.com/open-rmf/rmf/discussions/567#discussioncomment-12370285) where a robot waits for an excessive amount of time on a traffic dependency that has already moved out of the way.

The bug occurs when Robot A needs to wait at some point for Robot B to move out of the way, but Robot B has already **_completely finished its route_** before Robot A reaches the waiting point.

This PR detects whether Robot B has already finished its route while creating the dependency subscription, and immediately deprecates the dependency if true. If the robot has not finished its route at the time the dependency subscription is made, then there are other mechanisms that will detect the change and alert the waiting robot.