### PR TITLE
Add a method to audit the size of planner caches

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -601,6 +601,10 @@ public:
       const StartSet& start,
       std::size_t goal_vertex) const;
 
+
+  class CacheAudit;
+  CacheAudit cache_audit() const;
+
   class Implementation;
   class Debug;
 private:
@@ -762,6 +766,8 @@ public:
   /// do prevent the optimal solution from being available.
   std::vector<schedule::ParticipantId> blockers() const;
 
+
+
   class Implementation;
 private:
   Result();
@@ -880,6 +886,23 @@ private:
   rmf_utils::impl_ptr<Implementation> _pimpl;
 };
 
+//==============================================================================
+/// Number of elements in various caches within the planner.
+class Planner::CacheAudit
+{
+public:
+
+  std::size_t differential_drive_planner_cache_size() const;
+
+  std::size_t shortest_path_cache_size() const;
+
+  std::size_t euclidean_heuristic_cache_size() const;
+
+  class Implementation;
+private:
+  CacheAudit();
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
 
 /// Produces a set of possible starting waypoints and lanes in order to start
 /// planning. This method attempts to find the most suitable starting nodes
@@ -924,5 +947,14 @@ std::vector<Plan::Start> compute_plan_starts(
 
 } // namespace agv
 } // namespace rmf_traffic
+
+namespace std {
+
+//==============================================================================
+ostream& operator<<(
+  ostream& os,
+  const rmf_traffic::agv::Planner::CacheAudit& audit);
+
+} // namespace std
 
 #endif // RMF_TRAFFIC__AGV__PLANNER_HPP

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -1052,6 +1052,12 @@ auto Planner::quickest_path(
 }
 
 //==============================================================================
+auto Planner::cache_audit() const -> CacheAudit
+{
+  return _pimpl->interface->cache_audit();
+}
+
+//==============================================================================
 const Eigen::Vector3d& Plan::Waypoint::position() const
 {
   return _pimpl->position;
@@ -1146,6 +1152,31 @@ double Plan::get_cost() const
 Plan::Plan()
 {
   // Do nothing
+}
+
+//==============================================================================
+Planner::CacheAudit::CacheAudit()
+  : _pimpl(rmf_utils::make_impl<Implementation>())
+{
+  // Do nothing
+}
+
+//==============================================================================
+std::size_t Planner::CacheAudit::differential_drive_planner_cache_size() const
+{
+  return _pimpl->differential_drive_planner_cache_size;
+}
+
+//==============================================================================
+std::size_t Planner::CacheAudit::shortest_path_cache_size() const
+{
+  return _pimpl->shortest_path_cache_size;
+}
+
+//==============================================================================
+std::size_t Planner::CacheAudit::euclidean_heuristic_cache_size() const
+{
+  return _pimpl->euclidean_heuristic_cache_size;
 }
 
 //==============================================================================
@@ -1403,3 +1434,20 @@ std::size_t Planner::Debug::node_count(const Planner::Result& result)
 
 } // namespace agv
 } // namespace rmf_traffic
+
+namespace std {
+
+//==============================================================================
+ostream& operator<<(
+  ostream& os,
+  const rmf_traffic::agv::Planner::CacheAudit& audit)
+{
+  os << "Cache sizes:"
+     << "\n - DifferentialDrive: " << audit.differential_drive_planner_cache_size()
+     << "\n - ShortestPath: " << audit.shortest_path_cache_size()
+     << "\n - Euclidean: " << audit.euclidean_heuristic_cache_size();
+
+  return os;
+}
+
+} // namespace std

--- a/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
@@ -110,6 +110,22 @@ public:
     std::optional<Implementation> value);
 };
 
+//==============================================================================
+class Planner::CacheAudit::Implementation
+{
+public:
+  std::size_t differential_drive_planner_cache_size;
+  std::size_t shortest_path_cache_size;
+  std::size_t euclidean_heuristic_cache_size;
+
+  static Planner::CacheAudit make(Implementation impl)
+  {
+    CacheAudit audit;
+    *audit._pimpl = impl;
+    return audit;
+  }
+};
+
 } // namespace agv
 } // namespace rmf_traffic
 

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -127,6 +127,8 @@ public:
 
   virtual std::optional<PlanData> debug_step(Debugger& debugger) const = 0;
 
+  virtual Planner::CacheAudit cache_audit() const = 0;
+
   virtual ~Interface() = default;
 };
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/CacheManager.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/CacheManager.hpp
@@ -370,7 +370,7 @@ std::size_t CacheManagerMap<CacheArg>::net_size() const
   std::size_t count = 0;
   for (const auto [_, manager] : _managers)
   {
-    count += manager->inner().size();
+    count += manager->get().size();
   }
 
   return count;

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -509,9 +509,10 @@ private:
 
 //==============================================================================
 DifferentialDriveHeuristic::DifferentialDriveHeuristic(
-  std::shared_ptr<const Supergraph> graph)
+  std::shared_ptr<const Supergraph> graph,
+  ConstChildHeuristicPtr child_heuristic)
 : _graph(std::move(graph)),
-  _heuristic(std::make_shared<const ChildHeuristic>(_graph))
+  _heuristic(std::move(child_heuristic))
 {
   // Do nothing
 }
@@ -709,11 +710,14 @@ ConstForestSolutionPtr DifferentialDriveHeuristic::inner_heuristic(
 //==============================================================================
 CacheManagerPtr<DifferentialDriveHeuristic>
 DifferentialDriveHeuristic::make_manager(
-  std::shared_ptr<const Supergraph> supergraph)
+  std::shared_ptr<const Supergraph> supergraph,
+  ConstChildHeuristicPtr child_heuristic)
 {
   const std::size_t N = supergraph->original().lanes.size();
   return CacheManager<Cache<DifferentialDriveHeuristic>>::make(
-    std::make_shared<DifferentialDriveHeuristic>(std::move(supergraph)),
+    std::make_shared<DifferentialDriveHeuristic>(
+      std::move(supergraph),
+      std::move(child_heuristic)),
     [N]() { return Storage(4093, DifferentialDriveMapTypes::KeyHash{N}); });
 }
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
@@ -40,7 +40,9 @@ public:
 //  using ChildHeuristic = MinimalTravelHeuristic;
   using ConstChildHeuristicPtr = std::shared_ptr<const ChildHeuristic>;
 
-  DifferentialDriveHeuristic(std::shared_ptr<const Supergraph> graph);
+  DifferentialDriveHeuristic(
+    std::shared_ptr<const Supergraph> graph,
+    ConstChildHeuristicPtr child_heuristic);
 
   using SolutionNode = DifferentialDriveMapTypes::SolutionNode;
   using SolutionNodePtr = DifferentialDriveMapTypes::SolutionNodePtr;
@@ -56,7 +58,8 @@ public:
       std::size_t start, std::size_t finish) const;
 
   static CacheManagerPtr<DifferentialDriveHeuristic> make_manager(
-    std::shared_ptr<const Supergraph> graph);
+    std::shared_ptr<const Supergraph> graph,
+    ConstChildHeuristicPtr child_heuristic);
 
 private:
   std::shared_ptr<const Supergraph> _graph;

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
@@ -60,11 +60,14 @@ public:
 
   std::optional<PlanData> debug_step(Debugger& debugger) const final;
 
+  Planner::CacheAudit cache_audit() const final;
+
   std::optional<double> compute_heuristic(const Planner::Start& start) const;
 
 private:
   Planner::Configuration _config;
   std::shared_ptr<const Supergraph> _supergraph;
+  std::shared_ptr<const ShortestPathHeuristic> _shortest_path;
   CacheManagerPtr<DifferentialDriveHeuristic> _cache;
 };
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Supergraph.hpp
@@ -231,6 +231,11 @@ public:
     std::size_t goal_waypoint_index,
     std::optional<double> goal_orientation) const;
 
+  inline std::size_t lane_yaw_cache_size() const
+  {
+    return _lane_yaw_cache->get().size();
+  }
+
 private:
   Supergraph(
     Graph::Implementation original,

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Tree.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Tree.hpp
@@ -240,6 +240,10 @@ public:
 
   std::optional<double> get_cost(WaypointId start, WaypointId finish) const;
 
+  std::size_t cache_size() const;
+
+  std::size_t heuristic_cache_size() const;
+
   ~BidirectionalForest();
 
 private:

--- a/rmf_traffic/src/rmf_traffic/agv/planning/impl_Tree.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/impl_Tree.hpp
@@ -374,6 +374,27 @@ std::optional<double> BidirectionalForest<T>::get_cost(
 
 //==============================================================================
 template<typename T>
+std::size_t BidirectionalForest<T>::cache_size() const
+{
+    SpinLock lock(_solutions_mutex);
+    std::size_t count = 0;
+    for (const auto& [_, goals] : _solutions)
+    {
+      count += goals.size();
+    }
+
+    return count;
+}
+
+//==============================================================================
+template<typename T>
+std::size_t BidirectionalForest<T>::heuristic_cache_size() const
+{
+  return _heuristic_cache->net_size();
+}
+
+//==============================================================================
+template<typename T>
 BidirectionalForest<T>::~BidirectionalForest()
 {
   if constexpr (T::count_usage)

--- a/rmf_traffic/test/unit/agv/planning/test_DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_DifferentialDriveHeuristic.cpp
@@ -258,9 +258,13 @@ SCENARIO("Differential Drive Heuristic -- Peak and Valley")
     rmf_traffic::agv::Graph::Implementation::get(graph),
     traits, {}, rmf_traffic::agv::Interpolate::Options(), 0.1);
 
+  const auto shortest_path =
+    std::make_shared<rmf_traffic::agv::planning::ShortestPathHeuristic>(
+      supergraph);
+
   auto diff_drive_cache =
     rmf_traffic::agv::planning
-    ::DifferentialDriveHeuristic::make_manager(supergraph);
+    ::DifferentialDriveHeuristic::make_manager(supergraph, shortest_path);
 
   using Ori = rmf_traffic::agv::planning::Orientation;
   using Side = rmf_traffic::agv::planning::Side;
@@ -441,6 +445,10 @@ SCENARIO("Differential Drive Heuristic -- Indeterminate Yaw Edge Case")
     rmf_traffic::agv::Graph::Implementation::get(graph),
     traits, {}, rmf_traffic::agv::Interpolate::Options(), 0.1);
 
+  const auto shortest_path =
+    std::make_shared<rmf_traffic::agv::planning::ShortestPathHeuristic>(
+      supergraph);
+
   // TODO(MXG): Make a cleaner way to instantiate these caches
   using DifferentialDriveCache =
     rmf_traffic::agv::planning::CacheManager<
@@ -449,7 +457,8 @@ SCENARIO("Differential Drive Heuristic -- Indeterminate Yaw Edge Case")
   auto diff_drive_cache = DifferentialDriveCache::make(
     std::make_shared<
       rmf_traffic::agv::planning::DifferentialDriveHeuristic>(
-      supergraph), [N = supergraph->original().lanes.size()]()
+      supergraph,
+      shortest_path), [N = supergraph->original().lanes.size()]()
     {
       return rmf_traffic::agv::planning::DifferentialDriveHeuristic::Storage(
         4093,


### PR DESCRIPTION
This PR is being opened in response to https://github.com/open-rmf/rmf/discussions/664#discussioncomment-13070430

The main purpose is to give some rough insight into the memory size of the caches in the traffic planner. However while implementing the mechanism to check their sizes, I noticed an inefficiency: the `ShortestPathHeuristic` was being remade for each different goal search. I took this opportunity to tweak the implementation so that we create one single `ShortestPathHeuristic` instance per planner and use it across all goal searches. This should improve both performance and memory size.

Note that we currently expect the Euclidean cache to say its size is 0 because it's not being used in the current planner implementation. I kept it in there for completeness, in case we do go back to using it in the future.