### PR TITLE
Add an API for clearing the planner cache

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -603,7 +603,20 @@ public:
 
 
   class CacheAudit;
+  /// Get an audit of how much memory the planner's cache is using.
   CacheAudit cache_audit() const;
+
+  /// Clear the cache for the differential drive heuristic. This will clear
+  /// memory that the cache is occupying, but it will force the planner to
+  /// rebuild the cache the next time it needs to generate a plan.
+  ///
+  /// This function can be used to bring down memory utilization in cases where
+  /// the planner cache is ballooning. You can use the cache_audit function to
+  /// identify when the cache is getting excessively large.
+  ///
+  /// Clearing the cache too frequently could harm the planner's performance.
+  /// It is advisable to not clear the cache more than once per minute.
+  void clear_differential_drive_cache() const;
 
   class Implementation;
   class Debug;

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -1058,6 +1058,12 @@ auto Planner::cache_audit() const -> CacheAudit
 }
 
 //==============================================================================
+void Planner::clear_differential_drive_cache() const
+{
+  _pimpl->interface->clear_cache();
+}
+
+//==============================================================================
 const Eigen::Vector3d& Plan::Waypoint::position() const
 {
   return _pimpl->position;

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -129,6 +129,8 @@ public:
 
   virtual Planner::CacheAudit cache_audit() const = 0;
 
+  virtual void clear_cache() const = 0;
+
   virtual ~Interface() = default;
 };
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -2915,7 +2915,6 @@ std::optional<PlanData> DifferentialDrivePlanner::debug_step(
 //==============================================================================
 Planner::CacheAudit DifferentialDrivePlanner::cache_audit() const
 {
-
   auto audit = Planner::CacheAudit::Implementation{
     _cache->get().size(),
     _shortest_path->cache_size(),
@@ -2923,6 +2922,12 @@ Planner::CacheAudit DifferentialDrivePlanner::cache_audit() const
   };
 
   return Planner::CacheAudit::Implementation::make(audit);
+}
+
+//==============================================================================
+void DifferentialDrivePlanner::clear_cache() const
+{
+  _cache->get().clear();
 }
 
 } // namespace planning

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
@@ -62,6 +62,8 @@ public:
 
   Planner::CacheAudit cache_audit() const final;
 
+  void clear_cache() const final;
+
   std::optional<double> compute_heuristic(const Planner::Start& start) const;
 
 private:


### PR DESCRIPTION
Following up on https://github.com/open-rmf/rmf/discussions/664#discussioncomment-13084007 this PR provides an API for clearing out the cache within the planner that tends to grow the largest. This API can be called periodically to help manage inflation of a fleet adapter's memory.