### PR TITLE
Add API to clear planner inner cache

### DIFF
--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -598,8 +598,8 @@ public:
   /// \return The quickest path from the start to the finish, or a nullopt if
   /// there is no path that connects the start to the finish.
   std::optional<QuickestPath> quickest_path(
-      const StartSet& start,
-      std::size_t goal_vertex) const;
+    const StartSet& start,
+    std::size_t goal_vertex) const;
 
 
   class CacheAudit;
@@ -617,6 +617,8 @@ public:
   /// Clearing the cache too frequently could harm the planner's performance.
   /// It is advisable to not clear the cache more than once per minute.
   void clear_differential_drive_cache() const;
+
+  void clear_inner_cache() const;
 
   class Implementation;
   class Debug;
@@ -778,7 +780,6 @@ public:
   /// Blockers do not necessarily prevent a solution from being found, but they
   /// do prevent the optimal solution from being available.
   std::vector<schedule::ParticipantId> blockers() const;
-
 
 
   class Implementation;

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -598,8 +598,8 @@ public:
   /// \return The quickest path from the start to the finish, or a nullopt if
   /// there is no path that connects the start to the finish.
   std::optional<QuickestPath> quickest_path(
-    const StartSet& start,
-    std::size_t goal_vertex) const;
+      const StartSet& start,
+      std::size_t goal_vertex) const;
 
 
   class CacheAudit;
@@ -780,6 +780,7 @@ public:
   /// Blockers do not necessarily prevent a solution from being found, but they
   /// do prevent the optimal solution from being available.
   std::vector<schedule::ParticipantId> blockers() const;
+
 
 
   class Implementation;

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -1064,6 +1064,12 @@ void Planner::clear_differential_drive_cache() const
 }
 
 //==============================================================================
+void Planner::clear_inner_cache() const
+{
+  _pimpl->interface->clear_inner_cache();
+}
+
+//==============================================================================
 const Eigen::Vector3d& Plan::Waypoint::position() const
 {
   return _pimpl->position;
@@ -1162,7 +1168,7 @@ Plan::Plan()
 
 //==============================================================================
 Planner::CacheAudit::CacheAudit()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
@@ -1449,7 +1455,8 @@ ostream& operator<<(
   const rmf_traffic::agv::Planner::CacheAudit& audit)
 {
   os << "Cache sizes:"
-     << "\n - DifferentialDrive: " << audit.differential_drive_planner_cache_size()
+     << "\n - DifferentialDrive: " <<
+      audit.differential_drive_planner_cache_size()
      << "\n - ShortestPath: " << audit.shortest_path_cache_size()
      << "\n - Euclidean: " << audit.euclidean_heuristic_cache_size();
 

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -1455,8 +1455,7 @@ ostream& operator<<(
   const rmf_traffic::agv::Planner::CacheAudit& audit)
 {
   os << "Cache sizes:"
-     << "\n - DifferentialDrive: " <<
-      audit.differential_drive_planner_cache_size()
+     << "\n - DifferentialDrive: " << audit.differential_drive_planner_cache_size()
      << "\n - ShortestPath: " << audit.shortest_path_cache_size()
      << "\n - Euclidean: " << audit.euclidean_heuristic_cache_size();
 

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -1168,7 +1168,7 @@ Plan::Plan()
 
 //==============================================================================
 Planner::CacheAudit::CacheAudit()
-: _pimpl(rmf_utils::make_impl<Implementation>())
+  : _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -131,6 +131,8 @@ public:
 
   virtual void clear_cache() const = 0;
 
+  virtual void clear_inner_cache() const = 0;
+
   virtual ~Interface() = default;
 };
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -708,6 +708,13 @@ ConstForestSolutionPtr DifferentialDriveHeuristic::inner_heuristic(
 }
 
 //==============================================================================
+void DifferentialDriveHeuristic::clear_inner_heuristic() const
+{
+  std::cout << "clear inner heuristic "  << std::endl;
+  _heuristic->clear_cache();
+}
+
+//==============================================================================
 CacheManagerPtr<DifferentialDriveHeuristic>
 DifferentialDriveHeuristic::make_manager(
   std::shared_ptr<const Supergraph> supergraph,

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.cpp
@@ -710,7 +710,6 @@ ConstForestSolutionPtr DifferentialDriveHeuristic::inner_heuristic(
 //==============================================================================
 void DifferentialDriveHeuristic::clear_inner_heuristic() const
 {
-  std::cout << "clear inner heuristic "  << std::endl;
   _heuristic->clear_cache();
 }
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
@@ -38,7 +38,6 @@ public:
   // onto both implementations for now so we can continue experimenting.
   using ChildHeuristic = ShortestPathHeuristic;
 //  using ChildHeuristic = MinimalTravelHeuristic;
-
   using ConstChildHeuristicPtr = std::shared_ptr<const ChildHeuristic>;
 
   DifferentialDriveHeuristic(
@@ -56,7 +55,7 @@ public:
     Storage& new_items) const final;
 
   ConstForestSolutionPtr inner_heuristic(
-    std::size_t start, std::size_t finish) const;
+      std::size_t start, std::size_t finish) const;
 
   void clear_inner_heuristic() const;
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDriveHeuristic.hpp
@@ -38,6 +38,7 @@ public:
   // onto both implementations for now so we can continue experimenting.
   using ChildHeuristic = ShortestPathHeuristic;
 //  using ChildHeuristic = MinimalTravelHeuristic;
+
   using ConstChildHeuristicPtr = std::shared_ptr<const ChildHeuristic>;
 
   DifferentialDriveHeuristic(
@@ -55,7 +56,9 @@ public:
     Storage& new_items) const final;
 
   ConstForestSolutionPtr inner_heuristic(
-      std::size_t start, std::size_t finish) const;
+    std::size_t start, std::size_t finish) const;
+
+  void clear_inner_heuristic() const;
 
   static CacheManagerPtr<DifferentialDriveHeuristic> make_manager(
     std::shared_ptr<const Supergraph> graph,

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -636,14 +636,14 @@ reconstruct_waypoints(
     if (!same_pos && !same_ori)
     {
       candidates.push_back(WaypointCandidate{
-          true,
-          Plan::Waypoint::Implementation{
-            Eigen::Vector3d{prev_pos[0], prev_pos[1], node->yaw},
-            prev_wp.time, prev_wp.graph_index,
-            {}, {}, {}, prev_wp.event, {}
-          },
-          prev_candidate.velocity
-        });
+        true,
+        Plan::Waypoint::Implementation{
+          Eigen::Vector3d{prev_pos[0],  prev_pos[1], node->yaw},
+          prev_wp.time, prev_wp.graph_index,
+          {}, {}, {}, prev_wp.event, {}
+        },
+        prev_candidate.velocity
+      });
     }
 
     if (node->approach_lanes.empty())
@@ -1379,7 +1379,7 @@ public:
         top->current_cost + cost,
         std::nullopt,
         top,
-      __LINE__
+          __LINE__
       });
   }
 
@@ -1436,7 +1436,7 @@ public:
         top->current_cost + cost,
         std::nullopt,
         top,
-      __LINE__
+          __LINE__
       });
   }
 
@@ -1708,7 +1708,7 @@ public:
             node->current_cost + cost,
             std::nullopt,
             parent,
-            __LINE__
+          __LINE__
           });
       }
 
@@ -1899,8 +1899,7 @@ public:
         throw std::runtime_error(
           "[rmf_traffic::agv::planning::DifferentialDrivePlanner::expand] "
           "Node has no waypoint and also no start information. It was produced "
-          "on line [" + std::to_string(
-            top->line) + "]. This should not be "
+          "on line [" + std::to_string(top->line) + "]. This should not be "
           "possible. Please report this critical bug to the maintainers of "
           "rmf_traffic.");
       }
@@ -2180,7 +2179,7 @@ public:
         0.0,
         start,
         nullptr,
-      __LINE__
+          __LINE__
       });
   }
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -240,8 +240,8 @@ std::vector<NodePtr> reconstruct_nodes(
     Eigen::Vector3d p0{x[0], x[1], first_midlane_node->yaw};
     Eigen::Vector3d p1{x[0], x[1], last_midlane_node->yaw};
     internal::interpolate_rotation(
-        holding, w_nom, alpha_nom, first_midlane_node->time,
-        p0, p1, rotational_threshold);
+      holding, w_nom, alpha_nom, first_midlane_node->time,
+      p0, p1, rotational_threshold);
   }
 
   for (auto& cruft : cruft_map)
@@ -274,8 +274,8 @@ void stream_trajectory(
   for (const auto& wp : traj)
   {
     ss << wp.index() << ". t=" << time::to_seconds(wp.time().time_since_epoch())
-              << " p=(" << wp.position().transpose()
-              << ") v=<" << wp.velocity().transpose() << "> --> ";
+       << " p=(" << wp.position().transpose()
+       << ") v=<" << wp.velocity().transpose() << "> --> ";
   }
   ss << "(finished)\n";
 }
@@ -333,15 +333,15 @@ std::vector<Plan::Waypoint> find_dependencies(
           // This almost certainly means there's a bug causing an infinite loop.
           // A normal value would be less than 10.
           throw std::runtime_error(
-            "[rmf_traffic::agv::Planner::plan] Excessive iterating while "
-            "searching for plan dependencies. This likely indicates a bug in "
-            "the RouteValidator that was provided.");
+                  "[rmf_traffic::agv::Planner::plan] Excessive iterating while "
+                  "searching for plan dependencies. This likely indicates a bug in "
+                  "the RouteValidator that was provided.");
         }
 
         no_conflicts = true;
 
         for (auto t = dependency_resolution;
-             t < *dependency_window; t += dependency_resolution)
+          t < *dependency_window; t += dependency_resolution)
         {
           route.trajectory().front().adjust_times(-dependency_resolution);
           const auto conflict = validator->find_conflict(route);
@@ -388,26 +388,26 @@ std::vector<Plan::Waypoint> find_dependencies(
               no_conflicts = false;
               found_deps.push_back(dependency);
               const auto wp = [&]() -> std::optional<CheckpointId>
-              {
-                assert(!checkpoint_map.empty());
-                // Find the closest route waypoint less than or equal to
-                // `dependent` that is associated with a plan waypoint.
-                auto c_it = checkpoint_map.upper_bound(dependent);
-                if (c_it == checkpoint_map.begin())
                 {
-                  // If the upper bound is the first element in the checkpoint
-                  // map, then the real dependent is the previous route of this
-                  // plan. We don't have a way to express that in today's RMF,
-                  // so instead we will set the first checkpoint of this route
-                  // as a dependent and then skip further dependency checking.
-                  return std::nullopt;
-                }
+                  assert(!checkpoint_map.empty());
+                  // Find the closest route waypoint less than or equal to
+                  // `dependent` that is associated with a plan waypoint.
+                  auto c_it = checkpoint_map.upper_bound(dependent);
+                  if (c_it == checkpoint_map.begin())
+                  {
+                    // If the upper bound is the first element in the checkpoint
+                    // map, then the real dependent is the previous route of this
+                    // plan. We don't have a way to express that in today's RMF,
+                    // so instead we will set the first checkpoint of this route
+                    // as a dependent and then skip further dependency checking.
+                    return std::nullopt;
+                  }
 
-                --c_it;
-                route.add_dependency(c_it->first, dependency);
+                  --c_it;
+                  route.add_dependency(c_it->first, dependency);
 
-                return c_it->second;
-              } ();
+                  return c_it->second;
+                } ();
 
               if (wp.has_value())
               {
@@ -533,8 +533,12 @@ std::vector<Plan::Waypoint> find_dependencies(
         {
           const auto& trajectory_checkpoint = itinerary[r].trajectory()[id];
           const auto p_trajectory = trajectory_checkpoint.position();
-          const bool same_pos = (p_candidate.block<2,1>(0,0) - p_trajectory.block<2,1>(0,0)).norm() < 1e-2;
-          const bool same_ori = same_orientation(p_candidate[2], p_trajectory[2]);
+          const bool same_pos =
+            (p_candidate.block<2, 1>(0, 0) - p_trajectory.block<2, 1>(0,
+            0)).
+            norm() < 1e-2;
+          const bool same_ori =
+            same_orientation(p_candidate[2], p_trajectory[2]);
           if (same_pos && same_ori)
           {
             // We have a matching checkpoint
@@ -606,12 +610,12 @@ reconstruct_waypoints(
         n->route_from_parent.back().trajectory().back().position()
         .template block<2, 1>(0, 0);
       return WaypointCandidate{
-        true,
-        Plan::Waypoint::Implementation{
-          Eigen::Vector3d{p[0], p[1], n->yaw}, n->time, n->waypoint,
-          n->approach_lanes, {}, {}, n->event, {}
-        },
-        Eigen::Vector3d{0, 0, 0}
+      true,
+      Plan::Waypoint::Implementation{
+        Eigen::Vector3d{p[0], p[1], n->yaw}, n->time, n->waypoint,
+        n->approach_lanes, {}, {}, n->event, {}
+      },
+      Eigen::Vector3d{0, 0, 0}
       };
     };
 
@@ -636,14 +640,14 @@ reconstruct_waypoints(
     if (!same_pos && !same_ori)
     {
       candidates.push_back(WaypointCandidate{
-        true,
-        Plan::Waypoint::Implementation{
-          Eigen::Vector3d{prev_pos[0],  prev_pos[1], node->yaw},
-          prev_wp.time, prev_wp.graph_index,
-          {}, {}, {}, prev_wp.event, {}
-        },
-        prev_candidate.velocity
-      });
+          true,
+          Plan::Waypoint::Implementation{
+            Eigen::Vector3d{prev_pos[0], prev_pos[1], node->yaw},
+            prev_wp.time, prev_wp.graph_index,
+            {}, {}, {}, prev_wp.event, {}
+          },
+          prev_candidate.velocity
+        });
     }
 
     if (node->approach_lanes.empty())
@@ -663,14 +667,15 @@ reconstruct_waypoints(
       const auto opt_tv = [&]() -> std::optional<TimeVelocity>
         {
           if (necessary)
-            return TimeVelocity{node->time, {0, 0}};
+            return TimeVelocity{node->time, {0, 0}}
+          ;
 
           try
           {
             return interpolate_time_along_quadratic_straight_line(
               node->route_from_parent.back().trajectory(), p, 0.0);
           }
-          catch(const std::runtime_error& e)
+          catch (const std::runtime_error& e)
           {
             std::stringstream ss;
             ss << e.what()
@@ -682,7 +687,8 @@ reconstruct_waypoints(
             else
             {
               ss << "Entire trajectory:";
-              for (const rmf_traffic::Trajectory::Waypoint& wp : node->route_from_parent.back().trajectory())
+              for (const rmf_traffic::Trajectory::Waypoint& wp :
+                node->route_from_parent.back().trajectory())
               {
                 ss << " t=" << time::to_seconds(wp.time().time_since_epoch())
                    << " p=(" << wp.position().transpose()
@@ -716,13 +722,13 @@ reconstruct_waypoints(
       const auto [time, v] = *opt_tv;
 
       candidates.push_back({
-        necessary,
-        Plan::Waypoint::Implementation{
-          Eigen::Vector3d{p[0], p[1], yaw}, time, wp_index,
-          {lane_index}, {}, {}, necessary ? node->event : nullptr, {}
-        },
-        {v[0], v[1], 0.0}
-      });
+          necessary,
+          Plan::Waypoint::Implementation{
+            Eigen::Vector3d{p[0], p[1], yaw}, time, wp_index,
+            {lane_index}, {}, {}, necessary ? node->event : nullptr, {}
+          },
+          {v[0], v[1], 0.0}
+        });
     }
 
     for (const auto& skipped : skipped_lanes)
@@ -812,12 +818,12 @@ reconstruct_waypoints(
       }
 
       candidates.back().waypoint.arrival
-        .push_back({itinerary.size()-1, itinerary.back().trajectory().size()-1});
+      .push_back({itinerary.size()-1, itinerary.back().trajectory().size()-1});
     }
   }
 
   std::vector<std::size_t> removals;
-  for (std::size_t i=0; i < itinerary.size(); ++i)
+  for (std::size_t i = 0; i < itinerary.size(); ++i)
   {
     if (itinerary[i].trajectory().size() < 2)
     {
@@ -852,8 +858,8 @@ reconstruct_waypoints(
   }
 
   auto plan_waypoints = find_dependencies(
-      itinerary, candidates, validator,
-      dependency_window, dependency_resolution);
+    itinerary, candidates, validator,
+    dependency_window, dependency_resolution);
 
   return {itinerary, plan_waypoints};
 }
@@ -1149,7 +1155,7 @@ public:
             parent->current_cost + event_cost,
             std::nullopt,
             parent,
-          __LINE__
+            __LINE__
           });
       }
     }
@@ -1289,7 +1295,7 @@ public:
             node->current_cost + exit_event_cost,
             std::nullopt,
             node,
-          __LINE__
+            __LINE__
           });
       }
 
@@ -1379,7 +1385,7 @@ public:
         top->current_cost + cost,
         std::nullopt,
         top,
-          __LINE__
+        __LINE__
       });
   }
 
@@ -1436,7 +1442,7 @@ public:
         top->current_cost + cost,
         std::nullopt,
         top,
-          __LINE__
+        __LINE__
       });
   }
 
@@ -1522,7 +1528,7 @@ public:
 #endif // RMF_TRAFFIC__AGV__PLANNING__DEBUG__PLANNER
       if (traversal_yaw.has_value())
       {
-        const Eigen::Vector3d finish{p0.x(), p0.y(), * traversal_yaw};
+        const Eigen::Vector3d finish{p0.x(), p0.y(), *traversal_yaw};
         internal::interpolate_rotation(
           approach_trajectory, _w_nom, _alpha_nom, start_time,
           start, finish, _rotation_threshold);
@@ -1708,7 +1714,7 @@ public:
             node->current_cost + cost,
             std::nullopt,
             parent,
-          __LINE__
+            __LINE__
           });
       }
 
@@ -1767,7 +1773,7 @@ public:
             node->current_cost + exit_event_cost,
             std::nullopt,
             node,
-          __LINE__
+            __LINE__
           });
       }
 
@@ -1818,7 +1824,7 @@ public:
             search_node->current_cost + approach_info.cost,
             std::nullopt,
             search_node,
-          __LINE__
+            __LINE__
           });
       }
 
@@ -1867,7 +1873,7 @@ public:
             search_node->current_cost + solution_node->info.cost_from_parent,
             std::nullopt,
             search_node,
-          __LINE__
+            __LINE__
           });
 
         solution_node = solution_node->child;
@@ -1897,11 +1903,12 @@ public:
       if (!top->start.has_value())
       {
         throw std::runtime_error(
-          "[rmf_traffic::agv::planning::DifferentialDrivePlanner::expand] "
-          "Node has no waypoint and also no start information. It was produced "
-          "on line [" + std::to_string(top->line) + "]. This should not be "
-          "possible. Please report this critical bug to the maintainers of "
-          "rmf_traffic.");
+                "[rmf_traffic::agv::planning::DifferentialDrivePlanner::expand] "
+                "Node has no waypoint and also no start information. It was produced "
+                "on line [" + std::to_string(
+                  top->line) + "]. This should not be "
+                "possible. Please report this critical bug to the maintainers of "
+                "rmf_traffic.");
       }
       expand_start(top, queue);
       return;
@@ -1975,7 +1982,8 @@ public:
 
     const auto location_opt = start.location();
     if (!location_opt.has_value())
-      return {false, {}};
+      return {false, {}}
+    ;
 
     // This will return all the different trajectories that can be used to
     // approach the start. If it returns empty, that means either you forgot to
@@ -2179,7 +2187,7 @@ public:
         0.0,
         start,
         nullptr,
-          __LINE__
+        __LINE__
       });
   }
 
@@ -2253,7 +2261,8 @@ public:
       if (skip)
         continue;
 
-      while (original_node && !original_node->waypoint.has_value() && !original_node->start.has_value())
+      while (original_node && !original_node->waypoint.has_value() &&
+        !original_node->start.has_value())
       {
         original_node = original_node->parent;
       }
@@ -2472,7 +2481,7 @@ public:
       Issues issues;
 
       ScheduledDifferentialDriveExpander expander{
-        &internal,
+        & internal,
         issues,
         supergraph,
         DifferentialDriveHeuristicAdapter{
@@ -2698,7 +2707,8 @@ DifferentialDrivePlanner::DifferentialDrivePlanner(
 
   _shortest_path = std::make_shared<ShortestPathHeuristic>(_supergraph);
 
-  _cache = DifferentialDriveHeuristic::make_manager(_supergraph, _shortest_path);
+  _cache =
+    DifferentialDriveHeuristic::make_manager(_supergraph, _shortest_path);
 }
 
 //==============================================================================
@@ -2928,6 +2938,12 @@ Planner::CacheAudit DifferentialDrivePlanner::cache_audit() const
 void DifferentialDrivePlanner::clear_cache() const
 {
   _cache->get().clear();
+}
+
+//==============================================================================
+void DifferentialDrivePlanner::clear_inner_cache() const
+{
+  _cache->inner()->clear_inner_heuristic();
 }
 
 } // namespace planning

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -240,8 +240,8 @@ std::vector<NodePtr> reconstruct_nodes(
     Eigen::Vector3d p0{x[0], x[1], first_midlane_node->yaw};
     Eigen::Vector3d p1{x[0], x[1], last_midlane_node->yaw};
     internal::interpolate_rotation(
-      holding, w_nom, alpha_nom, first_midlane_node->time,
-      p0, p1, rotational_threshold);
+        holding, w_nom, alpha_nom, first_midlane_node->time,
+        p0, p1, rotational_threshold);
   }
 
   for (auto& cruft : cruft_map)
@@ -274,8 +274,8 @@ void stream_trajectory(
   for (const auto& wp : traj)
   {
     ss << wp.index() << ". t=" << time::to_seconds(wp.time().time_since_epoch())
-       << " p=(" << wp.position().transpose()
-       << ") v=<" << wp.velocity().transpose() << "> --> ";
+              << " p=(" << wp.position().transpose()
+              << ") v=<" << wp.velocity().transpose() << "> --> ";
   }
   ss << "(finished)\n";
 }
@@ -333,15 +333,15 @@ std::vector<Plan::Waypoint> find_dependencies(
           // This almost certainly means there's a bug causing an infinite loop.
           // A normal value would be less than 10.
           throw std::runtime_error(
-                  "[rmf_traffic::agv::Planner::plan] Excessive iterating while "
-                  "searching for plan dependencies. This likely indicates a bug in "
-                  "the RouteValidator that was provided.");
+            "[rmf_traffic::agv::Planner::plan] Excessive iterating while "
+            "searching for plan dependencies. This likely indicates a bug in "
+            "the RouteValidator that was provided.");
         }
 
         no_conflicts = true;
 
         for (auto t = dependency_resolution;
-          t < *dependency_window; t += dependency_resolution)
+             t < *dependency_window; t += dependency_resolution)
         {
           route.trajectory().front().adjust_times(-dependency_resolution);
           const auto conflict = validator->find_conflict(route);
@@ -388,26 +388,26 @@ std::vector<Plan::Waypoint> find_dependencies(
               no_conflicts = false;
               found_deps.push_back(dependency);
               const auto wp = [&]() -> std::optional<CheckpointId>
+              {
+                assert(!checkpoint_map.empty());
+                // Find the closest route waypoint less than or equal to
+                // `dependent` that is associated with a plan waypoint.
+                auto c_it = checkpoint_map.upper_bound(dependent);
+                if (c_it == checkpoint_map.begin())
                 {
-                  assert(!checkpoint_map.empty());
-                  // Find the closest route waypoint less than or equal to
-                  // `dependent` that is associated with a plan waypoint.
-                  auto c_it = checkpoint_map.upper_bound(dependent);
-                  if (c_it == checkpoint_map.begin())
-                  {
-                    // If the upper bound is the first element in the checkpoint
-                    // map, then the real dependent is the previous route of this
-                    // plan. We don't have a way to express that in today's RMF,
-                    // so instead we will set the first checkpoint of this route
-                    // as a dependent and then skip further dependency checking.
-                    return std::nullopt;
-                  }
+                  // If the upper bound is the first element in the checkpoint
+                  // map, then the real dependent is the previous route of this
+                  // plan. We don't have a way to express that in today's RMF,
+                  // so instead we will set the first checkpoint of this route
+                  // as a dependent and then skip further dependency checking.
+                  return std::nullopt;
+                }
 
-                  --c_it;
-                  route.add_dependency(c_it->first, dependency);
+                --c_it;
+                route.add_dependency(c_it->first, dependency);
 
-                  return c_it->second;
-                } ();
+                return c_it->second;
+              } ();
 
               if (wp.has_value())
               {
@@ -533,12 +533,8 @@ std::vector<Plan::Waypoint> find_dependencies(
         {
           const auto& trajectory_checkpoint = itinerary[r].trajectory()[id];
           const auto p_trajectory = trajectory_checkpoint.position();
-          const bool same_pos =
-            (p_candidate.block<2, 1>(0, 0) - p_trajectory.block<2, 1>(0,
-            0)).
-            norm() < 1e-2;
-          const bool same_ori =
-            same_orientation(p_candidate[2], p_trajectory[2]);
+          const bool same_pos = (p_candidate.block<2, 1>(0,0) - p_trajectory.block<2, 1>(0,0)).norm() < 1e-2;
+          const bool same_ori = same_orientation(p_candidate[2], p_trajectory[2]);
           if (same_pos && same_ori)
           {
             // We have a matching checkpoint
@@ -610,12 +606,12 @@ reconstruct_waypoints(
         n->route_from_parent.back().trajectory().back().position()
         .template block<2, 1>(0, 0);
       return WaypointCandidate{
-      true,
-      Plan::Waypoint::Implementation{
-        Eigen::Vector3d{p[0], p[1], n->yaw}, n->time, n->waypoint,
-        n->approach_lanes, {}, {}, n->event, {}
-      },
-      Eigen::Vector3d{0, 0, 0}
+        true,
+        Plan::Waypoint::Implementation{
+          Eigen::Vector3d{p[0], p[1], n->yaw}, n->time, n->waypoint,
+          n->approach_lanes, {}, {}, n->event, {}
+        },
+        Eigen::Vector3d{0, 0, 0}
       };
     };
 
@@ -667,15 +663,14 @@ reconstruct_waypoints(
       const auto opt_tv = [&]() -> std::optional<TimeVelocity>
         {
           if (necessary)
-            return TimeVelocity{node->time, {0, 0}}
-          ;
+            return TimeVelocity{node->time, {0, 0}};
 
           try
           {
             return interpolate_time_along_quadratic_straight_line(
               node->route_from_parent.back().trajectory(), p, 0.0);
           }
-          catch (const std::runtime_error& e)
+          catch(const std::runtime_error& e)
           {
             std::stringstream ss;
             ss << e.what()
@@ -687,8 +682,7 @@ reconstruct_waypoints(
             else
             {
               ss << "Entire trajectory:";
-              for (const rmf_traffic::Trajectory::Waypoint& wp :
-                node->route_from_parent.back().trajectory())
+              for (const rmf_traffic::Trajectory::Waypoint& wp : node->route_from_parent.back().trajectory())
               {
                 ss << " t=" << time::to_seconds(wp.time().time_since_epoch())
                    << " p=(" << wp.position().transpose()
@@ -722,13 +716,13 @@ reconstruct_waypoints(
       const auto [time, v] = *opt_tv;
 
       candidates.push_back({
-          necessary,
-          Plan::Waypoint::Implementation{
-            Eigen::Vector3d{p[0], p[1], yaw}, time, wp_index,
-            {lane_index}, {}, {}, necessary ? node->event : nullptr, {}
-          },
-          {v[0], v[1], 0.0}
-        });
+        necessary,
+        Plan::Waypoint::Implementation{
+          Eigen::Vector3d{p[0], p[1], yaw}, time, wp_index,
+          {lane_index}, {}, {}, necessary ? node->event : nullptr, {}
+        },
+        {v[0], v[1], 0.0}
+      });
     }
 
     for (const auto& skipped : skipped_lanes)
@@ -818,12 +812,12 @@ reconstruct_waypoints(
       }
 
       candidates.back().waypoint.arrival
-      .push_back({itinerary.size()-1, itinerary.back().trajectory().size()-1});
+        .push_back({itinerary.size()-1, itinerary.back().trajectory().size()-1});
     }
   }
 
   std::vector<std::size_t> removals;
-  for (std::size_t i = 0; i < itinerary.size(); ++i)
+  for (std::size_t i=0; i < itinerary.size(); ++i)
   {
     if (itinerary[i].trajectory().size() < 2)
     {
@@ -858,8 +852,8 @@ reconstruct_waypoints(
   }
 
   auto plan_waypoints = find_dependencies(
-    itinerary, candidates, validator,
-    dependency_window, dependency_resolution);
+      itinerary, candidates, validator,
+      dependency_window, dependency_resolution);
 
   return {itinerary, plan_waypoints};
 }
@@ -1155,7 +1149,7 @@ public:
             parent->current_cost + event_cost,
             std::nullopt,
             parent,
-            __LINE__
+          __LINE__
           });
       }
     }
@@ -1295,7 +1289,7 @@ public:
             node->current_cost + exit_event_cost,
             std::nullopt,
             node,
-            __LINE__
+          __LINE__
           });
       }
 
@@ -1385,7 +1379,7 @@ public:
         top->current_cost + cost,
         std::nullopt,
         top,
-        __LINE__
+      __LINE__
       });
   }
 
@@ -1442,7 +1436,7 @@ public:
         top->current_cost + cost,
         std::nullopt,
         top,
-        __LINE__
+      __LINE__
       });
   }
 
@@ -1528,7 +1522,7 @@ public:
 #endif // RMF_TRAFFIC__AGV__PLANNING__DEBUG__PLANNER
       if (traversal_yaw.has_value())
       {
-        const Eigen::Vector3d finish{p0.x(), p0.y(), *traversal_yaw};
+        const Eigen::Vector3d finish{p0.x(), p0.y(), * traversal_yaw};
         internal::interpolate_rotation(
           approach_trajectory, _w_nom, _alpha_nom, start_time,
           start, finish, _rotation_threshold);
@@ -1773,7 +1767,7 @@ public:
             node->current_cost + exit_event_cost,
             std::nullopt,
             node,
-            __LINE__
+          __LINE__
           });
       }
 
@@ -1824,7 +1818,7 @@ public:
             search_node->current_cost + approach_info.cost,
             std::nullopt,
             search_node,
-            __LINE__
+          __LINE__
           });
       }
 
@@ -1873,7 +1867,7 @@ public:
             search_node->current_cost + solution_node->info.cost_from_parent,
             std::nullopt,
             search_node,
-            __LINE__
+          __LINE__
           });
 
         solution_node = solution_node->child;
@@ -1903,12 +1897,12 @@ public:
       if (!top->start.has_value())
       {
         throw std::runtime_error(
-                "[rmf_traffic::agv::planning::DifferentialDrivePlanner::expand] "
-                "Node has no waypoint and also no start information. It was produced "
-                "on line [" + std::to_string(
-                  top->line) + "]. This should not be "
-                "possible. Please report this critical bug to the maintainers of "
-                "rmf_traffic.");
+          "[rmf_traffic::agv::planning::DifferentialDrivePlanner::expand] "
+          "Node has no waypoint and also no start information. It was produced "
+          "on line [" + std::to_string(
+            top->line) + "]. This should not be "
+          "possible. Please report this critical bug to the maintainers of "
+          "rmf_traffic.");
       }
       expand_start(top, queue);
       return;
@@ -1982,8 +1976,7 @@ public:
 
     const auto location_opt = start.location();
     if (!location_opt.has_value())
-      return {false, {}}
-    ;
+      return {false, {}};
 
     // This will return all the different trajectories that can be used to
     // approach the start. If it returns empty, that means either you forgot to
@@ -2187,7 +2180,7 @@ public:
         0.0,
         start,
         nullptr,
-        __LINE__
+      __LINE__
       });
   }
 
@@ -2261,8 +2254,7 @@ public:
       if (skip)
         continue;
 
-      while (original_node && !original_node->waypoint.has_value() &&
-        !original_node->start.has_value())
+      while (original_node && !original_node->waypoint.has_value() && !original_node->start.has_value())
       {
         original_node = original_node->parent;
       }
@@ -2481,7 +2473,7 @@ public:
       Issues issues;
 
       ScheduledDifferentialDriveExpander expander{
-        & internal,
+        &internal,
         issues,
         supergraph,
         DifferentialDriveHeuristicAdapter{
@@ -2707,8 +2699,7 @@ DifferentialDrivePlanner::DifferentialDrivePlanner(
 
   _shortest_path = std::make_shared<ShortestPathHeuristic>(_supergraph);
 
-  _cache =
-    DifferentialDriveHeuristic::make_manager(_supergraph, _shortest_path);
+  _cache = DifferentialDriveHeuristic::make_manager(_supergraph, _shortest_path);
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -533,7 +533,7 @@ std::vector<Plan::Waypoint> find_dependencies(
         {
           const auto& trajectory_checkpoint = itinerary[r].trajectory()[id];
           const auto p_trajectory = trajectory_checkpoint.position();
-          const bool same_pos = (p_candidate.block<2, 1>(0,0) - p_trajectory.block<2, 1>(0,0)).norm() < 1e-2;
+          const bool same_pos = (p_candidate.block<2,1>(0,0) - p_trajectory.block<2,1>(0,0)).norm() < 1e-2;
           const bool same_ori = same_orientation(p_candidate[2], p_trajectory[2]);
           if (same_pos && same_ori)
           {

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.hpp
@@ -64,6 +64,8 @@ public:
 
   void clear_cache() const final;
 
+  void clear_inner_cache() const final;
+
   std::optional<double> compute_heuristic(const Planner::Start& start) const;
 
 private:

--- a/rmf_traffic/src/rmf_traffic/agv/planning/Tree.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/Tree.hpp
@@ -242,7 +242,11 @@ public:
 
   std::size_t cache_size() const;
 
+  void clear_cache() const;
+
   std::size_t heuristic_cache_size() const;
+
+  void clear_heuristic_cache() const;
 
   ~BidirectionalForest();
 

--- a/rmf_traffic/src/rmf_traffic/agv/planning/impl_Tree.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/impl_Tree.hpp
@@ -376,14 +376,22 @@ std::optional<double> BidirectionalForest<T>::get_cost(
 template<typename T>
 std::size_t BidirectionalForest<T>::cache_size() const
 {
-    SpinLock lock(_solutions_mutex);
-    std::size_t count = 0;
-    for (const auto& [_, goals] : _solutions)
-    {
-      count += goals.size();
-    }
+  SpinLock lock(_solutions_mutex);
+  std::size_t count = 0;
+  for (const auto& [_, goals] : _solutions)
+  {
+    count += goals.size();
+  }
 
-    return count;
+  return count;
+}
+
+//==============================================================================
+template<typename T>
+void BidirectionalForest<T>::clear_cache() const
+{
+  SpinLock lock(_solutions_mutex);
+  _solutions.clear();
 }
 
 //==============================================================================
@@ -391,6 +399,14 @@ template<typename T>
 std::size_t BidirectionalForest<T>::heuristic_cache_size() const
 {
   return _heuristic_cache->net_size();
+}
+
+//==============================================================================
+template<typename T>
+void BidirectionalForest<T>::clear_heuristic_cache() const
+{
+  //TODO
+  throw std::runtime_error("clear_heuristic_cache is not implemented");
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/agv/planning/impl_Tree.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/impl_Tree.hpp
@@ -405,8 +405,8 @@ std::size_t BidirectionalForest<T>::heuristic_cache_size() const
 template<typename T>
 void BidirectionalForest<T>::clear_heuristic_cache() const
 {
-  //TODO
-  throw std::runtime_error("clear_heuristic_cache is not implemented");
+  // TODO: This is not implemented yet, but there should not be any negative
+  // impact on behavior by doing nothing here.
 }
 
 //==============================================================================


### PR DESCRIPTION
As a follow up on [https://discourse.openrobotics.org/t/memory-growth-in-fleet-adapter-and-traffic-schedule-664/44530/16](https://discourse.openrobotics.org/t/memory-growth-in-fleet-adapter-and-traffic-schedule-664/44530/16), this PR provides API for clearing planner inner cache. 