### PR TITLE
Embed mutex inside Planner::Result

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
@@ -18,6 +18,8 @@
 #ifndef SRC__RMF_TRAFFIC__AGV__INTERNAL_PLANNER_HPP
 #define SRC__RMF_TRAFFIC__AGV__INTERNAL_PLANNER_HPP
 
+#include <atomic>
+
 #include <rmf_traffic/agv/Planner.hpp>
 
 #include "internal_planning.hpp"
@@ -78,6 +80,7 @@ public:
   planning::InterfacePtr interface;
   planning::State state;
   std::optional<Plan> plan;
+  std::shared_ptr<std::atomic_bool> mutex;
 
   static Result generate(
     planning::InterfacePtr interface,


### PR DESCRIPTION
This is a supplemental fix for https://github.com/open-rmf/rmf_ros2/issues/462. The main fix is in https://github.com/open-rmf/rmf_ros2/pull/464, but this PR adds another layer of protection by ensuring that all access to a `Planner::Result` is thread-safe. That way we won't get data races from using `Planner::Result` in `rmf_fleet_adapter`, even if there are data race accesses to `Planner::Result` that we haven't caught yet.