### PR TITLE
chore: resolve C++ compiler warnings in agv planning and graph

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
@@ -176,7 +176,7 @@ bool Graph::DoorProperties::intersects(
 {
   const auto q0 = _pimpl->start;
   const auto q1 = _pimpl->end;
-  for (const auto test : std::vector<std::function<double()>>{
+  for (const auto& test : std::vector<std::function<double()>>{
       [&]{ return distance_from_point_to_segment(p0, q0, q1); },
       [&]{ return distance_from_point_to_segment(p1, q0, q1); },
       [&]{ return distance_from_point_to_segment(q0, p0, p1); },

--- a/rmf_traffic/src/rmf_traffic/agv/planning/CacheManager.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/CacheManager.hpp
@@ -385,7 +385,7 @@ std::size_t CacheManagerMap<CacheArg>::net_size() const
 {
   SpinLock lock(_map_mutex);
   std::size_t count = 0;
-  for (const auto [_, manager] : _managers)
+  for (const auto& [_, manager] : _managers)
   {
     count += manager->get().size();
   }

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -571,7 +571,7 @@ public:
   void execute(const LiftSessionEnd&) override {}
   void execute(const LiftMove&) override {}
   void execute(const Wait&) override {}
-  void execute(const Dock& dock) override
+  void execute(const Dock& /*dock*/) override
   {
     found = true;
   }
@@ -1195,7 +1195,7 @@ public:
     }
 
     Graph::Lane::EventPtr entry_event;
-    double entry_event_cost = 0.0;
+    [[maybe_unused]]double entry_event_cost = 0.0;
     Duration entry_event_duration = Duration(0);
 
     // If this start node did not have a waypoint, then it must have a location

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -571,7 +571,7 @@ public:
   void execute(const LiftSessionEnd&) override {}
   void execute(const LiftMove&) override {}
   void execute(const Wait&) override {}
-  void execute(const Dock& /*dock*/) override
+  void execute(const Dock&) override
   {
     found = true;
   }

--- a/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
@@ -1195,7 +1195,6 @@ public:
     }
 
     Graph::Lane::EventPtr entry_event;
-    [[maybe_unused]]double entry_event_cost = 0.0;
     Duration entry_event_duration = Duration(0);
 
     // If this start node did not have a waypoint, then it must have a location


### PR DESCRIPTION
### Description
This PR cleans up several compiler warnings that appear during a standard `colcon build` to reduce terminal noise and enforce better C++ practices.

### Before (Compiler Warnings)
> /src/rmf_traffic/agv/Graph.cpp:179:19: warning: loop variable ‘test’ creates a copy from type ‘const std::function<double()>’ [-Wrange-loop-construct]
> /src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp:574:28: warning: unused parameter ‘dock’ [-Wunused-parameter]
> /src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp:1198:12: warning: unused variable ‘entry_event_cost’ [-Wunused-variable]
> /src/rmf_traffic/agv/planning/CacheManager.hpp:388:19: warning: loop variable ‘<structured bindings>’ creates a copy [-Wrange-loop-construct]

### Changes made
* Added reference `&` to loop variables in `Graph.cpp` and `CacheManager.hpp` to resolve `-Wrange-loop-construct` warnings and prevent unnecessary object copying.
* Commented out the unused `dock` parameter name in `DifferentialDrivePlanner.cpp` (`-Wunused-parameter`).
* Added the `[[maybe_unused]]` attribute to `entry_event_cost` in `DifferentialDrivePlanner.cpp` (`-Wunused-variable`).

### After
Verified locally that `colcon build --packages-select rmf_traffic` now compiles completely cleanly without these warnings.