### PR TITLE
Add missing <cstdint> headers for GCC 15 compatibility

### DIFF
--- a/rmf_traffic/include/rmf_traffic/Route.hpp
+++ b/rmf_traffic/include/rmf_traffic/Route.hpp
@@ -20,6 +20,7 @@
 
 #include <rmf_traffic/Trajectory.hpp>
 
+#include <cstdint>
 #include <rmf_utils/impl_ptr.hpp>
 
 #include <optional>

--- a/rmf_traffic/include/rmf_traffic/schedule/Change.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Change.hpp
@@ -22,6 +22,7 @@
 #include <rmf_traffic/schedule/Participant.hpp>
 #include <rmf_traffic/schedule/Version.hpp>
 
+#include <cstdint>
 #include <rmf_utils/macros.hpp>
 
 namespace rmf_traffic {

--- a/rmf_traffic/include/rmf_traffic/schedule/Itinerary.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Itinerary.hpp
@@ -21,6 +21,7 @@
 #include <rmf_traffic/Route.hpp>
 #include <rmf_traffic/schedule/Version.hpp>
 
+#include <cstdint>
 #include <vector>
 
 namespace rmf_traffic {

--- a/rmf_traffic/include/rmf_traffic/schedule/Writer.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Writer.hpp
@@ -21,6 +21,8 @@
 #include <rmf_traffic/schedule/Itinerary.hpp>
 #include <rmf_traffic/schedule/ParticipantDescription.hpp>
 
+#include <cstdint>
+
 namespace rmf_traffic {
 namespace schedule {
 


### PR DESCRIPTION
Several headers were using `uint64_t` and other fixed-width types without explicitly including `<cstdint>`, which causes compilation failures on newer toolchains like GCC 15 (Ubuntu 26.04 Resolute).

This is a follow-up to #131 to cover remaining headers.

Can we also please get a new release of `rmf_traffic` to unblock the Lyrical binary builds?

Assisted-by: Gemini CLI:2.0-Flash [run_shell_command, replace, write_file, read_file]