### PR TITLE
Update CI to be consistent with other Open-RMF packages

### DIFF
--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -10,6 +10,6 @@ jobs:
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_asan.yaml@main
     with:
       packages: rmf_traffic
-      dist-matrix:
-        - "ros_distribution": "lyrical"
-          "ubuntu_distribution": "resolute"
+      dist-matrix: |
+        [{"ros_distribution": "lyrical",
+          "ubuntu_distribution": "resolute"}]

--- a/.github/workflows/asan.yaml
+++ b/.github/workflows/asan.yaml
@@ -6,48 +6,10 @@ on:
 
 jobs:
   asan:
-    name: asan
-    runs-on: ubuntu-22.04
-    container:
-      image: osrf/ros:jazzy-desktop-noble
-    steps:
-      - name: create_blacklist
-        run: |
-          mkdir -p ${{ github.workspace }}/
-          touch ${{ github.workspace }}/blacklist.txt
-          echo "fun:*Eigen*" > ${{ github.workspace }}/blacklist.txt
-      - name: install_clang_and_tools
-        run: sudo apt update && sudo apt install -y clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov
-      - name: build_and_test
-        uses: ros-tooling/action-ros-ci@v0.3
-        env:
-          CC: clang -fsanitize-blacklist=${{ github.workspace }}/blacklist.txt
-          CXX: clang++ -fsanitize-blacklist=${{ github.workspace }}/blacklist.txt
-        with:
-          target-ros2-distro: jazzy
-          # build all packages listed in the meta package
-          package-name: |
-            rmf_traffic
-          vcs-repo-file-url: |
-            https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
-          colcon-defaults: |
-            {
-              "build": {
-                "mixin": ["asan-gcc"],
-                "cmake-args": [
-                   "-DCMAKE_BUILD_TYPE=Debug"]
-              }
-            }
-          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - name: Upload failed test results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: test-results
-          path: ros_ws/build/*/test_results/*/*.catch2.xml
-      - name: upload_test_stream
-        uses: actions/upload-artifact@v4
-        with:
-          name: colcon-test-logs
-          path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
-        if: always()
+    name: Address Santization
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_asan.yaml@main
+    with:
+      packages: rmf_traffic
+      dist-matrix:
+        - "ros_distribution": "lyrical"
+          "ubuntu_distribution": "resolute"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,68 +1,16 @@
 name: build
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
   schedule:
     - cron: '55 0 * * *'
 
 jobs:
   build_and_test:
     name: Build and test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ros_distribution:
-          - humble
-          - jazzy
-          - rolling
-        include:
-          # Humble Hawksbill (May 2022 - May 2027)
-          - ubuntu_distribution: jammy
-            ros_distribution: humble
-            ros_version: 2
-          # Jazzy Jalisco (May 2024 - May 2029)
-          - ubuntu_distribution: noble
-            ros_distribution: jazzy
-            ros_version: 2
-          # Rolling Ridley (No End-Of-Life)
-          - ubuntu_distribution: noble
-            ros_distribution: rolling
-            ros_version: 2
-    container:
-      image: osrf/ros:${{ matrix.ros_distribution }}-desktop-${{ matrix.ubuntu_distribution }}
-    steps:
-      - name: pwd
-        run: pwd
-      - name: setup ROS environment
-        uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: ${{ matrix.ros_distribution }}
-      - name: build
-        uses: ros-tooling/action-ros-ci@v0.3
-        with:
-          target-ros2-distro: ${{ matrix.ros_distribution }}
-          # build all packages listed in the meta package
-          package-name: |
-            rmf_traffic
-          vcs-repo-file-url: |
-            https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
-          colcon-defaults: |
-            {
-              "build": {
-                "mixin": ["coverage-gcc"]
-              }
-            }
-          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - name: Upload failed test results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: test-results
-          path: ros_ws/build/*/test_results/*/*.catch2.xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          files: ros_ws/lcov/total_coverage.info
-          flags: tests
-          name: lean_and_mean_codecov_bot
-
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    with:
+      packages: rmf_traffic

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -10,6 +10,6 @@ jobs:
     uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_tsan.yaml@main
     with:
       packages: rmf_traffic
-      dist-matrix:
-        - "ros_distribution": "lyrical"
-          "ubuntu_distribution": "resolute"
+      dist-matrix: |
+        [{"ros_distribution": "lyrical",
+          "ubuntu_distribution": "resolute"}]

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -6,44 +6,10 @@ on:
 
 jobs:
   tsan:
-    name: tsan
-    runs-on: ubuntu-22.04
-    container:
-      image: osrf/ros:jazzy-desktop-noble
-    steps:
-      - name: install_clang_and_tools
-        run: sudo apt update && sudo apt install -y clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov
-      - name: tsan_build_test
-        env:
-          CC: clang
-          CXX: clang++
-        uses: ros-tooling/action-ros-ci@v0.3
-        id: tsan_build_test
-        with:
-          target-ros2-distro: jazzy
-          # build all packages listed in the meta package
-          package-name: |
-            rmf_traffic
-          vcs-repo-file-url: |
-            https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
-          colcon-defaults: |
-            {
-              "build": {
-                "mixin": ["tsan"],
-                "cmake-args": ["-DCMAKE_BUILD_TYPE=Debug"]
-              }
-            }
-          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - name: Upload failed test results
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: test-results
-          path: ros_ws/build/*/test_results/*/*.catch2.xml
-      - name: upload_test_stream
-        uses: actions/upload-artifact@v4
-        with:
-          name: colcon-test-logs
-          path: ${{ steps.tsan_build_test.outputs.ros-workspace-directory-name }}/log
-        if: always()
-
+    name: Thread Santization
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_tsan.yaml@main
+    with:
+      packages: rmf_traffic
+      dist-matrix:
+        - "ros_distribution": "lyrical"
+          "ubuntu_distribution": "resolute"

--- a/.github/workflows/tsan.yaml
+++ b/.github/workflows/tsan.yaml
@@ -7,9 +7,10 @@ on:
 jobs:
   tsan:
     name: Thread Santization
-    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_tsan.yaml@main
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
     with:
       packages: rmf_traffic
       dist-matrix: |
         [{"ros_distribution": "lyrical",
           "ubuntu_distribution": "resolute"}]
+      mixin: tsan

--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -57,7 +57,7 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
 
   ament_add_catch2(
     test_rmf_traffic test/main.cpp ${unit_test_srcs}
-    TIMEOUT 300)
+    TIMEOUT 3000)
   target_link_libraries(test_rmf_traffic
       rmf_traffic
       ${FCL_LIBRARIES}

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1058,7 +1058,9 @@ SCENARIO("Test planning")
     REQUIRE(plan->get_itinerary().front().trajectory().size() > 0);
     const auto t = plan->get_itinerary().front().trajectory();
     const auto final_p = t.front().position().block<2, 1>(0, 0);
-    const auto err = (final_p - Eigen::Vector2d(10, -5)).norm();
+    const auto expected_p = Eigen::Vector2d(10, -5);
+    const auto err = (final_p - expected_p).norm();
+    CAPTURE(final_p, expected_p, err);
     CHECK(err == Approx(0.0) );
     CHECK(t.back().position()[2] - goal_orientation == Approx(0));
     CHECK(t.back().time() > start_time);

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1057,9 +1057,9 @@ SCENARIO("Test planning")
     CHECK(plan->get_itinerary().size() == 1);
     REQUIRE(plan->get_itinerary().front().trajectory().size() > 0);
     const auto t = plan->get_itinerary().front().trajectory();
-    const auto final_p = t.front().position().block<2, 1>(0, 0);
-    const auto expected_p = Eigen::Vector2d(10, -5);
-    const auto err = (final_p - expected_p).norm();
+    const Eigen::Vector2d final_p = t.front().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d expected_p = Eigen::Vector2d(10, -5);
+    const double err = (final_p - expected_p).norm();
     CAPTURE(final_p, expected_p, err);
     CHECK(err == Approx(0.0) );
     CHECK(t.back().position()[2] - goal_orientation == Approx(0));


### PR DESCRIPTION
This updates the basic build of `rmf_traffic` to be consistent with other Open-RMF packages, i.e. keeping up with the default ROS distributions that we're targeting.